### PR TITLE
aktualizr-lite: Report results of `lshw` to server

### DIFF
--- a/src/aktualizr_lite/main.cc
+++ b/src/aktualizr_lite/main.cc
@@ -240,6 +240,12 @@ static int daemon_main(LiteClient &client, const bpo::variables_map &variables_m
     }
 
     client.primary->reportNetworkInfo();
+    // reportNetworkInfo already checks `telemetry.report_network`. We need a
+    // way when not running in anonymous mode to decide if we should report
+    // hwinfo to the server. This flag is a good one to (ab)use.
+    if (client.config.telemetry.report_network) {
+      client.primary->reportHwInfo();
+    }
 
     auto target = find_target(client.primary, hwid, client.config.pacman.tags, "latest");
     if (target != nullptr && !targets_eq(*target, current, compareDockerApps)) {

--- a/src/libaktualizr/primary/sotauptaneclient.cc
+++ b/src/libaktualizr/primary/sotauptaneclient.cc
@@ -175,7 +175,11 @@ data::InstallationResult SotaUptaneClient::PackageInstallSetResult(const Uptane:
 void SotaUptaneClient::reportHwInfo() {
   Json::Value hw_info = Utils::getHardwareInfo();
   if (!hw_info.empty()) {
-    http->put(config.tls.server + "/core/system_info", hw_info);
+    if (hw_info != last_hw_info_reported) {
+      if (http->put(config.tls.server + "/core/system_info", hw_info).isOk()) {
+        last_hw_info_reported = hw_info;
+      }
+    }
   } else {
     LOG_WARNING << "Unable to fetch hardware information from host system.";
   }

--- a/src/libaktualizr/primary/sotauptaneclient.h
+++ b/src/libaktualizr/primary/sotauptaneclient.h
@@ -67,6 +67,7 @@ class SotaUptaneClient {
   data::InstallationResult PackageInstall(const Uptane::Target &target);
   TargetStatus VerifyTarget(const Uptane::Target &target) { return package_manager_->verifyTarget(target); }
   void reportNetworkInfo();
+  void reportHwInfo();
 
  protected:
   void addSecondary(const std::shared_ptr<Uptane::SecondaryInterface> &sec);
@@ -112,7 +113,6 @@ class SotaUptaneClient {
                                                 const Uptane::EcuSerial &ecu_id);
   data::InstallationResult PackageInstallSetResult(const Uptane::Target &target);
   void finalizeAfterReboot();
-  void reportHwInfo();
   void reportInstalledPackages();
   void verifySecondaries();
   void sendMetadataToEcus(const std::vector<Uptane::Target> &targets);

--- a/src/libaktualizr/primary/sotauptaneclient.h
+++ b/src/libaktualizr/primary/sotauptaneclient.h
@@ -151,6 +151,7 @@ class SotaUptaneClient {
   std::shared_ptr<Bootloader> bootloader;
   std::shared_ptr<ReportQueue> report_queue;
   Json::Value last_network_info_reported;
+  Json::Value last_hw_info_reported;
   Uptane::EcuMap hw_ids;
   std::shared_ptr<event::Channel> events_channel;
   boost::signals2::connection conn;


### PR DESCRIPTION
Produces something like:
~~~
$ jobserv-curl https://api.foundries.io/ota/devices/rpi3-1/ | json_pp

{
   "created-at" : "2019-08-13T03:17:56+00:00",
   "docker-apps" : [
      "shellhttpd"
   ],
   "factory" : "andy-corp",
   "hardware-info" : {
      "capabilities" : {
         "cp15_barrier" : true,
         "setend" : true,
         "smp" : "Symmetric Multi-Processing",
         "swp" : true
      },
      "claimed" : true,
      "class" : "system",
      "description" : "Computer",
      "id" : "raspberrypi3-64-1",
      "product" : "Raspberry Pi 3 Model B",
      "serial" : "00000000132060de",
      "width" : 64
   },
 ...
~~~