### PR TITLE
[fio toup] dockerappmanager: Handle removed apps

### DIFF
--- a/src/libaktualizr/package_manager/docker_fake.sh
+++ b/src/libaktualizr/package_manager/docker_fake.sh
@@ -30,5 +30,10 @@ if [ "$1" = "up" ] ; then
   fi
   exit 0
 fi
+if [ "$1" = "down" ] ; then
+  echo "Fake downing the docker-app in $(pwd)"
+  touch ../docker-compose-down-called
+  exit 0
+fi
 echo "Unknown command: $*"
 exit 1

--- a/src/libaktualizr/package_manager/dockerappmanager.cc
+++ b/src/libaktualizr/package_manager/dockerappmanager.cc
@@ -38,6 +38,16 @@ struct DockerApp {
     return std::system(cmd.c_str()) == 0;
   }
 
+  void remove() {
+    auto bin = boost::filesystem::canonical(compose_bin).string();
+    std::string cmd("cd " + app_root.string() + " && " + bin + " down");
+    if (std::system(cmd.c_str()) == 0) {
+      boost::filesystem::remove_all(app_root);
+    } else {
+      LOG_ERROR << "docker-compose was unable to bring down: " << app_root;
+    }
+  }
+
   std::string name;
   boost::filesystem::path app_root;
   boost::filesystem::path app_params;
@@ -98,6 +108,7 @@ bool DockerAppManager::fetchTarget(const Uptane::Target &target, Uptane::Fetcher
 
 data::InstallationResult DockerAppManager::install(const Uptane::Target &target) const {
   auto res = OstreeManager::install(target);
+  handleRemovedApps();
   auto cb = [this](const std::string &app, const Uptane::Target &app_target) {
     LOG_INFO << "Installing " << app << " -> " << app_target;
     std::stringstream ss;
@@ -109,6 +120,24 @@ data::InstallationResult DockerAppManager::install(const Uptane::Target &target)
     return data::InstallationResult(data::ResultCode::Numeric::kInstallFailed, "Could not render docker app");
   }
   return res;
+}
+
+// Handle the case like:
+//  1) sota.toml is configured with 2 docker apps: "app1, app2"
+//  2) update is applied, so we are now running both app1 and app2
+//  3) sota.toml is updated with 1 docker app: "app1"
+// At this point we should stop app2 and remove it.
+void DockerAppManager::handleRemovedApps() const {
+  for (auto &entry : boost::make_iterator_range(boost::filesystem::directory_iterator(config.docker_apps_root), {})) {
+    if (boost::filesystem::is_directory(entry)) {
+      std::string name = entry.path().filename().native();
+      if (std::find(config.docker_apps.begin(), config.docker_apps.end(), name) == config.docker_apps.end()) {
+        LOG_WARNING << "Docker App(" << name
+                    << ") installed, but is now removed from configuration. Removing from system";
+        DockerApp(name, config).remove();
+      }
+    }
+  }
 }
 
 TargetStatus DockerAppManager::verifyTarget(const Uptane::Target &target) const {

--- a/src/libaktualizr/package_manager/dockerappmanager.h
+++ b/src/libaktualizr/package_manager/dockerappmanager.h
@@ -21,6 +21,7 @@ class DockerAppManager : public OstreeManager {
 
  private:
   bool iterate_apps(const Uptane::Target &target, const DockerAppCb &cb) const;
+  void handleRemovedApps() const;
 
   // iterate_apps needs an Uptane::Fetcher. However, its an unused parameter
   // and we just need to construct a dummy one to make the compiler happy.

--- a/src/libaktualizr/package_manager/packagemanagerconfig.cc
+++ b/src/libaktualizr/package_manager/packagemanagerconfig.cc
@@ -37,6 +37,7 @@ void PackageConfig::updateFromPropertyTree(const boost::property_tree::ptree& pt
   CopyFromConfig(val, "tags", pt);
   if (val.length() > 0) {
     boost::split(tags, val, boost::is_any_of(", "), boost::token_compress_on);
+    val.clear();  // this is re-used by docker_apps
   }
 #ifdef BUILD_DOCKERAPP
   CopyFromConfig(val, "docker_apps", pt);


### PR DESCRIPTION
There's a bug where:

 1) sota.toml is configured with 2 docker apps: "app1, app2"
 2) update is applied, so we are now running both app1 and app2
 3) sota.toml is updated with 1 docker app: "app1"

At this point the current logic will leave app2 running forever.
This change finds apps that have been removed, stops them, and removes
them from the filesystem.

Signed-off-by: Andy Doan <andy@foundries.io>