### PR TITLE
2019.9+fio Rebased Patches

### DIFF
--- a/src/aktualizr_get/main.cc
+++ b/src/aktualizr_get/main.cc
@@ -50,7 +50,7 @@ bpo::variables_map parse_options(int argc, char *argv[]) {
 }
 
 int main(int argc, char *argv[]) {
-  logger_init(isatty(1) == 1);
+  logger_init(isatty(1) == 1, false);
   logger_set_threshold(boost::log::trivial::info);
 
   bpo::variables_map commandline_map = parse_options(argc, argv);

--- a/src/aktualizr_lite/helpers.cc
+++ b/src/aktualizr_lite/helpers.cc
@@ -112,3 +112,28 @@ bool target_has_tags(const Uptane::Target &t, const std::vector<std::string> &co
   }
   return true;
 }
+
+bool targets_eq(const Uptane::Target &t1, const Uptane::Target &t2, bool compareDockerApps) {
+  // target equality check looks at hashes
+  if (t1.MatchTarget(t2)) {
+    if (compareDockerApps) {
+      auto t1_apps = t1.custom_data()["docker_apps"];
+      auto t2_apps = t2.custom_data()["docker_apps"];
+      for (Json::ValueIterator i = t1_apps.begin(); i != t1_apps.end(); ++i) {
+        auto app = i.key().asString();
+        if (!t2_apps.isMember(app)) {
+          return false;  // an app has been removed
+        }
+        if ((*i)["filename"].asString() != t2_apps[app]["filename"].asString()) {
+          return false;  // tuf target filename changed
+        }
+        t2_apps.removeMember(app);
+      }
+      if (t2_apps.size() > 0) {
+        return false;  // an app has been added
+      }
+    }
+    return true;  // docker apps are the same, or there are none
+  }
+  return false;
+}

--- a/src/aktualizr_lite/helpers.cc
+++ b/src/aktualizr_lite/helpers.cc
@@ -56,3 +56,17 @@ LiteClient::LiteClient(Config &config_in) : config(std::move(config_in)) {
   primary = std::make_shared<SotaUptaneClient>(config, storage, http_client, bootloader, report_queue);
   finalizeIfNeeded(*storage, config.pacman);
 }
+
+bool target_has_tags(const Uptane::Target &t, const std::vector<std::string> &config_tags) {
+  if (!config_tags.empty()) {
+    auto tags = t.custom_data()["tags"];
+    for (Json::ValueIterator i = tags.begin(); i != tags.end(); ++i) {
+      auto tag = (*i).asString();
+      if (std::find(config_tags.begin(), config_tags.end(), tag) != config_tags.end()) {
+        return true;
+      }
+    }
+    return false;
+  }
+  return true;
+}

--- a/src/aktualizr_lite/helpers.cc
+++ b/src/aktualizr_lite/helpers.cc
@@ -16,7 +16,7 @@ static void add_apps_header(std::vector<std::string> &headers, PackageConfig &co
   {}
 #endif
 
-static Uptane::Target finalizeIfNeeded(INvStorage &storage, PackageConfig &config) {
+static std::pair<bool, Uptane::Target> finalizeIfNeeded(INvStorage &storage, PackageConfig &config) {
   boost::optional<Uptane::Target> pending_version;
   storage.loadInstalledVersions("", nullptr, &pending_version);
 
@@ -32,7 +32,7 @@ static Uptane::Target finalizeIfNeeded(INvStorage &storage, PackageConfig &confi
     if (current_hash == target.sha256Hash()) {
       LOG_INFO << "Marking target install complete for: " << target;
       storage.saveInstalledVersion("", target, InstalledVersionUpdateMode::kCurrent);
-      return target;
+      return std::make_pair(true, target);
     }
   }
 
@@ -46,13 +46,13 @@ static Uptane::Target finalizeIfNeeded(INvStorage &storage, PackageConfig &confi
   std::vector<Uptane::Target>::reverse_iterator it;
   for (it = installed_versions.rbegin(); it != installed_versions.rend(); it++) {
     if (it->sha256Hash() == current_hash) {
-      return *it;
+      return std::make_pair(false, *it);
     }
   }
-  return Uptane::Target::Unknown();
+  return std::make_pair(false, Uptane::Target::Unknown());
 }
 
-LiteClient::LiteClient(Config &config_in) : config(std::move(config_in)) {
+LiteClient::LiteClient(Config &config_in) : config(std::move(config_in)), primary_serial(Uptane::EcuSerial::Unknown()) {
   std::string pkey;
   storage = INvStorage::newStorage(config.storage);
   storage->importData(config.import);
@@ -69,8 +69,11 @@ LiteClient::LiteClient(Config &config_in) : config(std::move(config_in)) {
       boost::uuids::uuid tmp = boost::uuids::random_generator()();
       serial = boost::uuids::to_string(tmp);
     }
-    ecu_serials.emplace_back(Uptane::EcuSerial(serial), Uptane::HardwareIdentifier(hwid));
+    primary_serial = Uptane::EcuSerial(serial);
+    ecu_serials.emplace_back(primary_serial, Uptane::HardwareIdentifier(hwid));
     storage->storeEcuSerials(ecu_serials);
+  } else {
+    primary_serial = ecu_serials[0].first;
   }
 
   std::vector<std::string> headers;
@@ -85,18 +88,61 @@ LiteClient::LiteClient(Config &config_in) : config(std::move(config_in)) {
   headers.push_back(header);
   add_apps_header(headers, config.pacman);
 
-  Uptane::Target tgt = finalizeIfNeeded(*storage, config.pacman);
-  headers.emplace_back("x-ats-target: " + tgt.filename());
+  std::pair<bool, Uptane::Target> pair = finalizeIfNeeded(*storage, config.pacman);
+  headers.emplace_back("x-ats-target: " + pair.second.filename());
   headers.emplace_back("x-ats-tags: " + boost::algorithm::join(config.pacman.tags, ","));
 
   auto http_client = std::make_shared<HttpClient>(&headers);
   auto bootloader = std::make_shared<Bootloader>(config.bootloader, *storage);
-  auto report_queue = std::make_shared<ReportQueue>(config, http_client);
+  report_queue = std::make_shared<ReportQueue>(config, http_client);
+
+  if (pair.first) {
+    notifyInstallFinished(pair.second, data::ResultCode::Numeric::kOk);
+  }
 
   KeyManager keys(storage, config.keymanagerConfig());
   keys.copyCertsToCurl(*http_client);
 
   primary = std::make_shared<SotaUptaneClient>(config, storage, http_client, bootloader, report_queue);
+}
+
+void LiteClient::notify(const Uptane::Target &t, std::unique_ptr<ReportEvent> event) {
+  if (!config.tls.server.empty()) {
+    event->custom["targetName"] = t.filename();
+    event->custom["version"] = t.custom_version();
+    report_queue->enqueue(std::move(event));
+  }
+}
+
+void LiteClient::notifyDownloadStarted(const Uptane::Target &t) {
+  notify(t, std_::make_unique<EcuDownloadStartedReport>(primary_serial, t.correlation_id()));
+}
+
+void LiteClient::notifyDownloadFinished(const Uptane::Target &t, bool success) {
+  notify(t, std_::make_unique<EcuDownloadCompletedReport>(primary_serial, t.correlation_id(), success));
+}
+
+void LiteClient::notifyInstallStarted(const Uptane::Target &t) {
+  notify(t, std_::make_unique<EcuInstallationStartedReport>(primary_serial, t.correlation_id()));
+}
+
+void LiteClient::notifyInstallFinished(const Uptane::Target &t, data::ResultCode::Numeric rc) {
+  if (rc == data::ResultCode::Numeric::kNeedCompletion) {
+    notify(t, std_::make_unique<EcuInstallationAppliedReport>(primary_serial, t.correlation_id()));
+  } else if (rc == data::ResultCode::Numeric::kOk) {
+    notify(t, std_::make_unique<EcuInstallationCompletedReport>(primary_serial, t.correlation_id(), true));
+  } else {
+    notify(t, std_::make_unique<EcuInstallationCompletedReport>(primary_serial, t.correlation_id(), false));
+  }
+}
+
+void generate_correlation_id(Uptane::Target &t) {
+  std::string id = t.custom_version();
+  if (id.empty()) {
+    id = t.filename();
+  }
+  boost::uuids::uuid tmp = boost::uuids::random_generator()();
+  t.setCorrelationId(id + "-" + boost::uuids::to_string(tmp));
 }
 
 bool target_has_tags(const Uptane::Target &t, const std::vector<std::string> &config_tags) {

--- a/src/aktualizr_lite/helpers.cc
+++ b/src/aktualizr_lite/helpers.cc
@@ -5,24 +5,51 @@
 
 #include "package_manager/ostreemanager.h"
 
-static void finalizeIfNeeded(INvStorage &storage, PackageConfig &config) {
+#ifdef BUILD_DOCKERAPP
+static void add_apps_header(std::vector<std::string> &headers, PackageConfig &config) {
+  if (config.type == PackageManager::kOstreeDockerApp) {
+    headers.emplace_back("x-ats-dockerapps: " + boost::algorithm::join(config.docker_apps, ","));
+  }
+}
+#else
+#define add_apps_header(headers, config) \
+  {}
+#endif
+
+static Uptane::Target finalizeIfNeeded(INvStorage &storage, PackageConfig &config) {
   boost::optional<Uptane::Target> pending_version;
   storage.loadInstalledVersions("", nullptr, &pending_version);
 
-  if (!!pending_version) {
-    GObjectUniquePtr<OstreeSysroot> sysroot_smart = OstreeManager::LoadSysroot(config.sysroot);
-    OstreeDeployment *booted_deployment = ostree_sysroot_get_booted_deployment(sysroot_smart.get());
-    if (booted_deployment == nullptr) {
-      throw std::runtime_error("Could not get booted deployment in " + config.sysroot.string());
-    }
-    std::string current_hash = ostree_deployment_get_csum(booted_deployment);
+  GObjectUniquePtr<OstreeSysroot> sysroot_smart = OstreeManager::LoadSysroot(config.sysroot);
+  OstreeDeployment *booted_deployment = ostree_sysroot_get_booted_deployment(sysroot_smart.get());
+  std::string current_hash = ostree_deployment_get_csum(booted_deployment);
+  if (booted_deployment == nullptr) {
+    throw std::runtime_error("Could not get booted deployment in " + config.sysroot.string());
+  }
 
+  if (!!pending_version) {
     const Uptane::Target &target = *pending_version;
     if (current_hash == target.sha256Hash()) {
       LOG_INFO << "Marking target install complete for: " << target;
       storage.saveInstalledVersion("", target, InstalledVersionUpdateMode::kCurrent);
+      return target;
     }
   }
+
+  std::vector<Uptane::Target> installed_versions;
+  storage.loadPrimaryInstallationLog(&installed_versions, false);
+
+  // Version should be in installed versions. Its possible that multiple
+  // targets could have the same sha256Hash. In this case the safest assumption
+  // is that the most recent (the reverse of the vector) target is what we
+  // should return.
+  std::vector<Uptane::Target>::reverse_iterator it;
+  for (it = installed_versions.rbegin(); it != installed_versions.rend(); it++) {
+    if (it->sha256Hash() == current_hash) {
+      return *it;
+    }
+  }
+  return Uptane::Target::Unknown();
 }
 
 LiteClient::LiteClient(Config &config_in) : config(std::move(config_in)) {
@@ -46,7 +73,23 @@ LiteClient::LiteClient(Config &config_in) : config(std::move(config_in)) {
     storage->storeEcuSerials(ecu_serials);
   }
 
-  auto http_client = std::make_shared<HttpClient>();
+  std::vector<std::string> headers;
+  GObjectUniquePtr<OstreeSysroot> sysroot_smart = OstreeManager::LoadSysroot(config.pacman.sysroot);
+  OstreeDeployment *deployment = ostree_sysroot_get_booted_deployment(sysroot_smart.get());
+  std::string header("x-ats-ostreehash: ");
+  if (deployment != nullptr) {
+    header += ostree_deployment_get_csum(deployment);
+  } else {
+    header += "?";
+  }
+  headers.push_back(header);
+  add_apps_header(headers, config.pacman);
+
+  Uptane::Target tgt = finalizeIfNeeded(*storage, config.pacman);
+  headers.emplace_back("x-ats-target: " + tgt.filename());
+  headers.emplace_back("x-ats-tags: " + boost::algorithm::join(config.pacman.tags, ","));
+
+  auto http_client = std::make_shared<HttpClient>(&headers);
   auto bootloader = std::make_shared<Bootloader>(config.bootloader, *storage);
   auto report_queue = std::make_shared<ReportQueue>(config, http_client);
 
@@ -54,7 +97,6 @@ LiteClient::LiteClient(Config &config_in) : config(std::move(config_in)) {
   keys.copyCertsToCurl(*http_client);
 
   primary = std::make_shared<SotaUptaneClient>(config, storage, http_client, bootloader, report_queue);
-  finalizeIfNeeded(*storage, config.pacman);
 }
 
 bool target_has_tags(const Uptane::Target &t, const std::vector<std::string> &config_tags) {

--- a/src/aktualizr_lite/helpers.h
+++ b/src/aktualizr_lite/helpers.h
@@ -6,6 +6,7 @@
 #include <string.h>
 
 #include "primary/sotauptaneclient.h"
+#include "uptane/tuf.h"
 
 struct Version {
   std::string raw_ver;
@@ -21,5 +22,7 @@ struct LiteClient {
   std::shared_ptr<INvStorage> storage;
   std::shared_ptr<SotaUptaneClient> primary;
 };
+
+bool target_has_tags(const Uptane::Target& t, const std::vector<std::string>& config_tags);
 
 #endif  // AKTUALIZR_LITE_HELPERS

--- a/src/aktualizr_lite/helpers.h
+++ b/src/aktualizr_lite/helpers.h
@@ -24,5 +24,6 @@ struct LiteClient {
 };
 
 bool target_has_tags(const Uptane::Target& t, const std::vector<std::string>& config_tags);
+bool targets_eq(const Uptane::Target& t1, const Uptane::Target& t2, bool compareDockerApps);
 
 #endif  // AKTUALIZR_LITE_HELPERS

--- a/src/aktualizr_lite/helpers.h
+++ b/src/aktualizr_lite/helpers.h
@@ -21,8 +21,18 @@ struct LiteClient {
   Config config;
   std::shared_ptr<INvStorage> storage;
   std::shared_ptr<SotaUptaneClient> primary;
+  std::shared_ptr<ReportQueue> report_queue;
+  Uptane::EcuSerial primary_serial;
+
+  void notifyDownloadStarted(const Uptane::Target& t);
+  void notifyDownloadFinished(const Uptane::Target& t, bool success);
+  void notifyInstallStarted(const Uptane::Target& t);
+  void notifyInstallFinished(const Uptane::Target& t, data::ResultCode::Numeric rc);
+
+  void notify(const Uptane::Target& t, std::unique_ptr<ReportEvent> event);
 };
 
+void generate_correlation_id(Uptane::Target& t);
 bool target_has_tags(const Uptane::Target& t, const std::vector<std::string>& config_tags);
 bool targets_eq(const Uptane::Target& t1, const Uptane::Target& t2, bool compareDockerApps);
 

--- a/src/aktualizr_lite/helpers_test.cc
+++ b/src/aktualizr_lite/helpers_test.cc
@@ -51,6 +51,37 @@ TEST(helpers, lite_client_finalize) {
   ASSERT_FALSE(target.MatchHash(LiteClient(config).primary->getCurrent().hashes()[0]));
 }
 
+TEST(helpers, target_has_tags) {
+  auto t = Uptane::Target::Unknown();
+
+  // No tags defined in target:
+  std::vector<std::string> config_tags;
+  ASSERT_TRUE(target_has_tags(t, config_tags));
+  config_tags.push_back("foo");
+  ASSERT_FALSE(target_has_tags(t, config_tags));
+
+  // Set target tags to: premerge, qa
+  auto custom = t.custom_data();
+  custom["tags"].append("premerge");
+  custom["tags"].append("qa");
+  t.updateCustom(custom);
+
+  config_tags.clear();
+  ASSERT_TRUE(target_has_tags(t, config_tags));
+
+  config_tags.push_back("qa");
+  config_tags.push_back("blah");
+  ASSERT_TRUE(target_has_tags(t, config_tags));
+
+  config_tags.clear();
+  config_tags.push_back("premerge");
+  ASSERT_TRUE(target_has_tags(t, config_tags));
+
+  config_tags.clear();
+  config_tags.push_back("foo");
+  ASSERT_FALSE(target_has_tags(t, config_tags));
+}
+
 #ifndef __NO_MAIN__
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);

--- a/src/aktualizr_lite/helpers_test.cc
+++ b/src/aktualizr_lite/helpers_test.cc
@@ -82,6 +82,47 @@ TEST(helpers, target_has_tags) {
   ASSERT_FALSE(target_has_tags(t, config_tags));
 }
 
+TEST(helpers, targets_eq) {
+  auto t1 = Uptane::Target::Unknown();
+  auto t2 = Uptane::Target::Unknown();
+
+  // t1 should equal t2 when there a no docker-apps
+  ASSERT_TRUE(targets_eq(t1, t2, false));
+  ASSERT_TRUE(targets_eq(t1, t2, true));
+
+  auto custom = t1.custom_data();
+  custom["docker_apps"]["app1"]["filename"] = "app1-v1";
+  t1.updateCustom(custom);
+  ASSERT_TRUE(targets_eq(t1, t2, false));  // still equal, ignoring docker-apps
+  ASSERT_FALSE(targets_eq(t1, t2, true));
+
+  custom = t2.custom_data();
+  custom["docker_apps"]["app1"]["filename"] = "app1-v1";
+  t2.updateCustom(custom);
+  ASSERT_TRUE(targets_eq(t1, t2, true));
+
+  custom["docker_apps"]["app1"]["filename"] = "app1-v2";
+  t2.updateCustom(custom);
+  ASSERT_FALSE(targets_eq(t1, t2, true));  // version has changed
+
+  // Get things the same again
+  custom["docker_apps"]["app1"]["filename"] = "app1-v1";
+  t2.updateCustom(custom);
+
+  custom["docker_apps"]["app2"]["filename"] = "app2-v2";
+  t2.updateCustom(custom);
+  ASSERT_FALSE(targets_eq(t1, t2, true));  // t2 has an app that t1 doesn't
+
+  custom = t1.custom_data();
+  custom["docker_apps"]["app2"]["filename"] = "app2-v1";
+  t1.updateCustom(custom);
+  ASSERT_FALSE(targets_eq(t1, t2, true));  // app2 versions differ
+
+  custom["docker_apps"]["app2"]["filename"] = "app2-v2";
+  t1.updateCustom(custom);
+  ASSERT_TRUE(targets_eq(t1, t2, true));
+}
+
 #ifndef __NO_MAIN__
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);

--- a/src/aktualizr_lite/main.cc
+++ b/src/aktualizr_lite/main.cc
@@ -167,6 +167,10 @@ static int daemon_main(LiteClient &client, const bpo::variables_map &variables_m
     LOG_ERROR << "[uptane]/repo_server is not configured";
     return 1;
   }
+  if (access(client.config.bootloader.reboot_command.c_str(), X_OK) != 0) {
+    LOG_ERROR << "reboot command: " << client.config.bootloader.reboot_command << " is not executable";
+    return 1;
+  }
   bool compareDockerApps = should_compare_docker_apps(client.config);
   Uptane::HardwareIdentifier hwid(client.config.provision.primary_ecu_hardware_id);
 
@@ -187,7 +191,10 @@ static int daemon_main(LiteClient &client, const bpo::variables_map &variables_m
     if (target != nullptr && !targets_eq(*target, current, compareDockerApps)) {
       LOG_INFO << "Updating base image to: " << *target;
       if (do_update(client, *target) == 0) {
-        // TODO reboot
+        if (std::system(client.config.bootloader.reboot_command.c_str()) != 0) {
+          LOG_ERROR << "Unable to reboot system";
+          return 1;
+        }
       }
     }
     std::this_thread::sleep_for(std::chrono::seconds(interval));

--- a/src/aktualizr_lite/main.cc
+++ b/src/aktualizr_lite/main.cc
@@ -223,6 +223,9 @@ static int daemon_main(LiteClient &client, const bpo::variables_map &variables_m
     if (!client.primary->updateImagesMeta()) {
       LOG_WARNING << "Unable to update latest metadata, using local copy";
     }
+
+    client.primary->reportNetworkInfo();
+
     auto target = find_target(client.primary, hwid, client.config.pacman.tags, "latest");
     if (target != nullptr && !targets_eq(*target, current, compareDockerApps)) {
       LOG_INFO << "Updating base image to: " << *target;
@@ -343,6 +346,7 @@ int main(int argc, char *argv[]) {
 
     Config config(commandline_map);
     config.storage.uptane_metadata_path = BasedPath(config.storage.path / "metadata");
+    config.telemetry.report_network = !config.tls.server.empty();
     LOG_DEBUG << "Current directory: " << boost::filesystem::current_path().string();
 
     std::string cmd = commandline_map["command"].as<std::string>();

--- a/src/aktualizr_lite/main.cc
+++ b/src/aktualizr_lite/main.cc
@@ -11,6 +11,13 @@
 
 namespace bpo = boost::program_options;
 
+#ifdef BUILD_DOCKERAPP
+#define should_compare_docker_apps(config) \
+  (config.pacman.type == PackageManager::kOstreeDockerApp && !config.pacman.docker_apps.empty())
+#else
+#define should_compare_docker_apps(config) (false)
+#endif
+
 static void log_info_target(const std::string &prefix, const Config &config, const Uptane::Target &t) {
   auto name = t.filename();
   if (t.custom_version().length() > 0) {
@@ -155,6 +162,39 @@ static int update_main(LiteClient &client, const bpo::variables_map &variables_m
   return do_update(client, *target);
 }
 
+static int daemon_main(LiteClient &client, const bpo::variables_map &variables_map) {
+  if (client.config.uptane.repo_server.empty()) {
+    LOG_ERROR << "[uptane]/repo_server is not configured";
+    return 1;
+  }
+  bool compareDockerApps = should_compare_docker_apps(client.config);
+  Uptane::HardwareIdentifier hwid(client.config.provision.primary_ecu_hardware_id);
+
+  auto current = client.primary->getCurrent();
+  LOG_INFO << "Active image is: " << current;
+
+  uint64_t interval = client.config.uptane.polling_sec;
+  if (variables_map.count("interval") > 0) {
+    interval = variables_map["interval"].as<uint64_t>();
+  }
+
+  while (true) {
+    LOG_INFO << "Refreshing target metadata";
+    if (!client.primary->updateImagesMeta()) {
+      LOG_WARNING << "Unable to update latest metadata, using local copy";
+    }
+    auto target = find_target(client.primary, hwid, client.config.pacman.tags, "latest");
+    if (target != nullptr && !targets_eq(*target, current, compareDockerApps)) {
+      LOG_INFO << "Updating base image to: " << *target;
+      if (do_update(client, *target) == 0) {
+        // TODO reboot
+      }
+    }
+    std::this_thread::sleep_for(std::chrono::seconds(interval));
+  }
+  return 0;
+}
+
 struct SubCommand {
   const char *name;
   int (*main)(LiteClient &, const bpo::variables_map &);
@@ -163,6 +203,7 @@ static SubCommand commands[] = {
     {"status", status_main},
     {"list", list_main},
     {"update", update_main},
+    {"daemon", daemon_main},
 };
 
 void check_info_options(const bpo::options_description &description, const bpo::variables_map &vm) {
@@ -197,6 +238,7 @@ bpo::variables_map parse_options(int argc, char *argv[]) {
       ("ostree-server", bpo::value<std::string>(), "url of the ostree repository")
       ("primary-ecu-hardware-id", bpo::value<std::string>(), "hardware ID of primary ecu")
       ("update-name", bpo::value<std::string>(), "optional name of the update when running \"update\". default=latest")
+      ("interval", bpo::value<uint64_t>(), "Override uptane.polling_secs interval to poll for update when in daemon mode.")
       ("command", bpo::value<std::string>(), subs.c_str());
   // clang-format on
 

--- a/src/aktualizr_lite/main.cc
+++ b/src/aktualizr_lite/main.cc
@@ -138,11 +138,16 @@ static int get_lock(const char *lockfile) {
 }
 
 static int do_update(LiteClient &client, Uptane::Target &target, const char *lockfile) {
+  generate_correlation_id(target);
+  client.notifyDownloadStarted(target);
   if (!client.primary->downloadImage(target).first) {
+    client.notifyDownloadFinished(target, false);
     return 1;
   }
+  client.notifyDownloadFinished(target, true);
 
   if (client.primary->VerifyTarget(target) != TargetStatus::kGood) {
+    client.notifyInstallFinished(target, data::ResultCode::Numeric::kValidationFailed);
     LOG_ERROR << "Downloaded target is invalid";
   }
 
@@ -151,7 +156,9 @@ static int do_update(LiteClient &client, Uptane::Target &target, const char *loc
     return 1;
   }
 
+  client.notifyInstallStarted(target);
   auto iresult = client.primary->PackageInstall(target);
+  client.notifyInstallFinished(target, iresult.result_code.num_code);
   if (iresult.result_code.num_code == data::ResultCode::Numeric::kNeedCompletion) {
     LOG_INFO << "Update complete. Please reboot the device to activate";
     client.storage->savePrimaryInstalledVersion(target, InstalledVersionUpdateMode::kPending);
@@ -220,7 +227,11 @@ static int daemon_main(LiteClient &client, const bpo::variables_map &variables_m
     if (target != nullptr && !targets_eq(*target, current, compareDockerApps)) {
       LOG_INFO << "Updating base image to: " << *target;
       if (do_update(client, *target, lockfile) == 0) {
-        if (std::system(client.config.bootloader.reboot_command.c_str()) != 0) {
+        if (target->MatchHash(current.hashes()[0])) {
+          LOG_INFO << "Update applied, hashes haven't changed";
+          client.storage->savePrimaryInstalledVersion(*target, InstalledVersionUpdateMode::kCurrent);
+          current = *target;
+        } else if (std::system(client.config.bootloader.reboot_command.c_str()) != 0) {
           LOG_ERROR << "Unable to reboot system";
           return 1;
         }

--- a/src/aktualizr_lite/main.cc
+++ b/src/aktualizr_lite/main.cc
@@ -1,3 +1,4 @@
+#include <sys/file.h>
 #include <unistd.h>
 #include <iostream>
 
@@ -121,13 +122,32 @@ static std::unique_ptr<Uptane::Target> find_target(const std::shared_ptr<SotaUpt
   throw std::runtime_error("Unable to find update");
 }
 
-static int do_update(LiteClient &client, Uptane::Target &target) {
+static int get_lock(const char *lockfile) {
+  int fd = open(lockfile, O_RDWR | O_CREAT | O_APPEND, 0666);
+  if (fd < 0) {
+    LOG_ERROR << "Unable to open lock file";
+    return -1;
+  }
+  LOG_INFO << "Acquiring lock";
+  if (flock(fd, LOCK_EX) < 0) {
+    LOG_ERROR << "Unable to acquire lock";
+    close(fd);
+    return -1;
+  }
+  return fd;
+}
+
+static int do_update(LiteClient &client, Uptane::Target &target, const char *lockfile) {
   if (!client.primary->downloadImage(target).first) {
     return 1;
   }
 
   if (client.primary->VerifyTarget(target) != TargetStatus::kGood) {
     LOG_ERROR << "Downloaded target is invalid";
+  }
+
+  int lockfd = 0;
+  if (lockfile != nullptr && (lockfd = get_lock(lockfile)) < 0) {
     return 1;
   }
 
@@ -137,8 +157,11 @@ static int do_update(LiteClient &client, Uptane::Target &target) {
     client.storage->savePrimaryInstalledVersion(target, InstalledVersionUpdateMode::kPending);
   } else if (iresult.result_code.num_code == data::ResultCode::Numeric::kOk) {
     client.storage->savePrimaryInstalledVersion(target, InstalledVersionUpdateMode::kCurrent);
+    close(lockfd);
   } else {
     LOG_ERROR << "Unable to install update: " << iresult.description;
+    // let go of the lock since we couldn't update
+    close(lockfd);
     return 1;
   }
   LOG_INFO << iresult.description;
@@ -159,7 +182,7 @@ static int update_main(LiteClient &client, const bpo::variables_map &variables_m
     return 0;
   }
   LOG_INFO << "Updating to: " << *target;
-  return do_update(client, *target);
+  return do_update(client, *target, nullptr);
 }
 
 static int daemon_main(LiteClient &client, const bpo::variables_map &variables_map) {
@@ -173,6 +196,12 @@ static int daemon_main(LiteClient &client, const bpo::variables_map &variables_m
   }
   bool compareDockerApps = should_compare_docker_apps(client.config);
   Uptane::HardwareIdentifier hwid(client.config.provision.primary_ecu_hardware_id);
+  const char *lockfile = nullptr;
+  boost::filesystem::path lockfilePath;
+  if (variables_map.count("update-lockfile") > 0) {
+    lockfilePath = variables_map["update-lockfile"].as<boost::filesystem::path>();
+    lockfile = lockfilePath.c_str();
+  }
 
   auto current = client.primary->getCurrent();
   LOG_INFO << "Active image is: " << current;
@@ -190,7 +219,7 @@ static int daemon_main(LiteClient &client, const bpo::variables_map &variables_m
     auto target = find_target(client.primary, hwid, client.config.pacman.tags, "latest");
     if (target != nullptr && !targets_eq(*target, current, compareDockerApps)) {
       LOG_INFO << "Updating base image to: " << *target;
-      if (do_update(client, *target) == 0) {
+      if (do_update(client, *target, lockfile) == 0) {
         if (std::system(client.config.bootloader.reboot_command.c_str()) != 0) {
           LOG_ERROR << "Unable to reboot system";
           return 1;
@@ -246,6 +275,7 @@ bpo::variables_map parse_options(int argc, char *argv[]) {
       ("primary-ecu-hardware-id", bpo::value<std::string>(), "hardware ID of primary ecu")
       ("update-name", bpo::value<std::string>(), "optional name of the update when running \"update\". default=latest")
       ("interval", bpo::value<uint64_t>(), "Override uptane.polling_secs interval to poll for update when in daemon mode.")
+      ("update-lockfile", bpo::value<boost::filesystem::path>(), "If provided, an flock(2) is applied to this file before performing an update in daemon mode")
       ("command", bpo::value<std::string>(), subs.c_str());
   // clang-format on
 

--- a/src/aktualizr_lite/main.cc
+++ b/src/aktualizr_lite/main.cc
@@ -137,42 +137,53 @@ static int get_lock(const char *lockfile) {
   return fd;
 }
 
-static int do_update(LiteClient &client, Uptane::Target &target, const char *lockfile) {
+static data::ResultCode::Numeric do_update(LiteClient &client, Uptane::Target &target, const char *lockfile) {
   generate_correlation_id(target);
   client.notifyDownloadStarted(target);
   if (!client.primary->downloadImage(target).first) {
     client.notifyDownloadFinished(target, false);
-    return 1;
+    return data::ResultCode::Numeric::kDownloadFailed;
   }
   client.notifyDownloadFinished(target, true);
 
   if (client.primary->VerifyTarget(target) != TargetStatus::kGood) {
     client.notifyInstallFinished(target, data::ResultCode::Numeric::kValidationFailed);
     LOG_ERROR << "Downloaded target is invalid";
+    return data::ResultCode::Numeric::kValidationFailed;
   }
 
   int lockfd = 0;
   if (lockfile != nullptr && (lockfd = get_lock(lockfile)) < 0) {
-    return 1;
+    return data::ResultCode::Numeric::kInternalError;
   }
+
+  Uptane::Target current = client.primary->getCurrent();
 
   client.notifyInstallStarted(target);
   auto iresult = client.primary->PackageInstall(target);
+  // Make sure the update wasn't just for docker-apps
+  if (iresult.result_code.num_code == data::ResultCode::Numeric::kNeedCompletion) {
+    for (const auto &it : current.hashes()) {
+      if (target.MatchHash(it)) {
+        iresult.result_code.num_code = data::ResultCode::Numeric::kOk;
+        break;
+      }
+    }
+  }
   client.notifyInstallFinished(target, iresult.result_code.num_code);
   if (iresult.result_code.num_code == data::ResultCode::Numeric::kNeedCompletion) {
     LOG_INFO << "Update complete. Please reboot the device to activate";
     client.storage->savePrimaryInstalledVersion(target, InstalledVersionUpdateMode::kPending);
   } else if (iresult.result_code.num_code == data::ResultCode::Numeric::kOk) {
+    LOG_INFO << "Update complete. No reboot needed";
     client.storage->savePrimaryInstalledVersion(target, InstalledVersionUpdateMode::kCurrent);
     close(lockfd);
   } else {
     LOG_ERROR << "Unable to install update: " << iresult.description;
     // let go of the lock since we couldn't update
     close(lockfd);
-    return 1;
   }
-  LOG_INFO << iresult.description;
-  return 0;
+  return iresult.result_code.num_code;
 }
 
 static int update_main(LiteClient &client, const bpo::variables_map &variables_map) {
@@ -189,7 +200,11 @@ static int update_main(LiteClient &client, const bpo::variables_map &variables_m
     return 0;
   }
   LOG_INFO << "Updating to: " << *target;
-  return do_update(client, *target, nullptr);
+  data::ResultCode::Numeric rc = do_update(client, *target, nullptr);
+  if (rc == data::ResultCode::Numeric::kNeedCompletion || rc == data::ResultCode::Numeric::kOk) {
+    return 0;
+  }
+  return 1;
 }
 
 static int daemon_main(LiteClient &client, const bpo::variables_map &variables_map) {
@@ -235,12 +250,12 @@ static int daemon_main(LiteClient &client, const bpo::variables_map &variables_m
     auto target = find_target(client.primary, hwid, client.config.pacman.tags, "latest");
     if (target != nullptr && !targets_eq(*target, current, compareDockerApps)) {
       LOG_INFO << "Updating base image to: " << *target;
-      if (do_update(client, *target, lockfile) == 0) {
-        if (target->MatchHash(current.hashes()[0])) {
-          LOG_INFO << "Update applied, hashes haven't changed";
-          client.storage->savePrimaryInstalledVersion(*target, InstalledVersionUpdateMode::kCurrent);
-          current = *target;
-        } else if (std::system(client.config.bootloader.reboot_command.c_str()) != 0) {
+
+      data::ResultCode::Numeric rc = do_update(client, *target, lockfile);
+      if (rc == data::ResultCode::Numeric::kOk) {
+        current = *target;
+      } else if (rc == data::ResultCode::Numeric::kNeedCompletion) {
+        if (std::system(client.config.bootloader.reboot_command.c_str()) != 0) {
           LOG_ERROR << "Unable to reboot system";
           return 1;
         }

--- a/src/aktualizr_lite/main.cc
+++ b/src/aktualizr_lite/main.cc
@@ -225,6 +225,12 @@ static int daemon_main(LiteClient &client, const bpo::variables_map &variables_m
     }
 
     client.primary->reportNetworkInfo();
+    // reportNetworkInfo already checks `telemetry.report_network`. We need a
+    // way when not running in anonymous mode to decide if we should report
+    // hwinfo to the server. This flag is a good one to (ab)use.
+    if (client.config.telemetry.report_network) {
+      client.primary->reportHwInfo();
+    }
 
     auto target = find_target(client.primary, hwid, client.config.pacman.tags, "latest");
     if (target != nullptr && !targets_eq(*target, current, compareDockerApps)) {

--- a/src/aktualizr_lite/test_lite.sh
+++ b/src/aktualizr_lite/test_lite.sh
@@ -70,16 +70,16 @@ repo_server = "http://localhost:$port/repo/repo"
 [provision]
 primary_ecu_hardware_id = "hwid-for-test"
 
-[pacman]
-type = "ostree"
-sysroot = "$OSTREE_SYSROOT"
-os = "dummy-os"
-
 [storage]
 type = "sqlite"
 path = "$sota_dir"
 sqldb_path = "sql.db"
 uptane_metadata_path = "$sota_dir/metadata"
+
+[pacman]
+type = "ostree"
+sysroot = "$OSTREE_SYSROOT"
+os = "dummy-os"
 EOF
 
 ## Check that we can do the info command
@@ -114,3 +114,8 @@ if [[ ! "$out" =~ "Active image is: zlast	sha256:$sha" ]] ; then
     echo $out
     exit 1
 fi
+
+## Make sure we obey tags
+echo 'tags = "promoted"' >> $sota_dir/sota.toml
+cd /tmp/
+OSTREE_HASH=$sha LD_PRELOAD=$mock_ostree $valgrind $aklite --loglevel 1 -c $sota_dir/sota.toml update | grep "Already up-to-date"

--- a/src/libaktualizr/config/config.h
+++ b/src/libaktualizr/config/config.h
@@ -51,7 +51,7 @@ struct ProvisionConfig {
 };
 
 struct UptaneConfig {
-  uint64_t polling_sec{10u};
+  uint64_t polling_sec{300u};
   std::string director_server;
   std::string repo_server;
   CryptoSource key_source{CryptoSource::kFile};

--- a/src/libaktualizr/config/config.h
+++ b/src/libaktualizr/config/config.h
@@ -100,7 +100,8 @@ class Config : public BaseConfig {
   void updateFromPropertyTree(const boost::property_tree::ptree& pt) override;
   void updateFromCommandLine(const boost::program_options::variables_map& cmd);
 
-  std::vector<boost::filesystem::path> config_dirs_ = {"/usr/lib/sota/conf.d", "/etc/sota/conf.d/"};
+  std::vector<boost::filesystem::path> config_dirs_ = {"/usr/lib/sota/conf.d", "/var/sota/sota.toml",
+                                                       "/etc/sota/conf.d/"};
   bool loglevel_from_cmdline{false};
 };
 

--- a/src/libaktualizr/http/httpclient.cc
+++ b/src/libaktualizr/http/httpclient.cc
@@ -257,4 +257,20 @@ std::future<HttpResponse> HttpClient::downloadAsync(const std::string& url, curl
   return resp_future;
 }
 
+bool HttpClient::updateHeader(const std::string& name, const std::string& value) {
+  curl_slist* item = headers;
+  std::string lookfor(name + ": ");
+
+  while (item != nullptr) {
+    if (strncmp(lookfor.c_str(), item->data, lookfor.length()) == 0) {
+      free(item->data);
+      lookfor += value;
+      item->data = strdup(lookfor.c_str());
+      return true;
+    }
+    item = item->next;
+  }
+  return false;
+}
+
 // vim: set tabstop=2 shiftwidth=2 expandtab:

--- a/src/libaktualizr/http/httpclient.h
+++ b/src/libaktualizr/http/httpclient.h
@@ -41,6 +41,7 @@ class HttpClient : public HttpInterface {
                                           CurlHandler *easyp) override;
   void setCerts(const std::string &ca, CryptoSource ca_source, const std::string &cert, CryptoSource cert_source,
                 const std::string &pkey, CryptoSource pkey_source) override;
+  bool updateHeader(const std::string &name, const std::string &value);
 
  private:
   FRIEND_TEST(GetTest, download_speed_limit);

--- a/src/libaktualizr/http/httpclient_test.cc
+++ b/src/libaktualizr/http/httpclient_test.cc
@@ -100,6 +100,18 @@ TEST(HttpClient, user_agent) {
   }
 }
 
+TEST(Headers, update_header) {
+  std::vector<std::string> headers = {"Authorization: Bearer bad"};
+  HttpClient http(&headers);
+
+  ASSERT_FALSE(http.updateHeader("NOSUCHHEADER", "foo"));
+
+  ASSERT_TRUE(http.updateHeader("Authorization", "Bearer token"));
+  std::string path = "/auth_call";
+  Json::Value response = http.get(server + path, HttpInterface::kNoLimit).getJson();
+  EXPECT_EQ(response["status"].asString(), "good");
+}
+
 // TODO: add tests for HttpClient::download
 
 #ifndef __NO_MAIN__

--- a/src/libaktualizr/logging/android_log_sink.cc
+++ b/src/libaktualizr/logging/android_log_sink.cc
@@ -16,8 +16,9 @@ class android_log_sink : public log::sinks::basic_sink_backend<log::sinks::synch
   }
 };
 
-void logger_init_sink(bool use_colors = false) {
+void logger_init_sink(bool use_colors = false, bool use_stdout = true) {
   (void)use_colors;
+  (void)use_stdout;
   typedef log::sinks::synchronous_sink<android_log_sink> android_log_sink_t;
   log::core::get()->add_sink(boost::shared_ptr<android_log_sink_t>(new android_log_sink_t()));
 }

--- a/src/libaktualizr/logging/default_log_sink.cc
+++ b/src/libaktualizr/logging/default_log_sink.cc
@@ -29,8 +29,12 @@ static void color_fmt(boost::log::record_view const& rec, boost::log::formatting
   }
 }
 
-void logger_init_sink(bool use_colors = false) {
-  auto sink = boost::log::add_console_log(std::cout, boost::log::keywords::format = "%Message%",
+void logger_init_sink(bool use_colors = false, bool use_stdout = true) {
+  auto stream = &std::cerr;
+  if (use_stdout) {
+    stream = &std::cout;
+  }
+  auto sink = boost::log::add_console_log(*stream, boost::log::keywords::format = "%Message%",
                                           boost::log::keywords::auto_flush = true);
   if (use_colors) {
     sink->set_formatter(&color_fmt);

--- a/src/libaktualizr/logging/logging.cc
+++ b/src/libaktualizr/logging/logging.cc
@@ -4,14 +4,14 @@ using boost::log::trivial::severity_level;
 
 static severity_level gLoggingThreshold;
 
-extern void logger_init_sink(bool use_colors = false);
+extern void logger_init_sink(bool use_colors = false, bool use_stdout = true);
 
 int64_t get_curlopt_verbose() { return gLoggingThreshold <= boost::log::trivial::trace ? 1L : 0L; }
 
-void logger_init(bool use_colors) {
+void logger_init(bool use_colors, bool use_stdout) {
   gLoggingThreshold = boost::log::trivial::info;
 
-  logger_init_sink(use_colors);
+  logger_init_sink(use_colors, use_stdout);
 
   boost::log::core::get()->set_filter(boost::log::trivial::severity >= gLoggingThreshold);
 }

--- a/src/libaktualizr/logging/logging.h
+++ b/src/libaktualizr/logging/logging.h
@@ -30,7 +30,7 @@
 // curl_easy_setopt(curl_handle, CURLOPT_VERBOSE, get_curlopt_verbose());
 int64_t get_curlopt_verbose();
 
-void logger_init(bool use_colors = false);
+void logger_init(bool use_colors = false, bool use_stdout = true);
 
 void logger_set_threshold(boost::log::trivial::severity_level threshold);
 

--- a/src/libaktualizr/package_manager/docker_fake.sh
+++ b/src/libaktualizr/package_manager/docker_fake.sh
@@ -30,5 +30,10 @@ if [ "$1" = "up" ] ; then
   fi
   exit 0
 fi
+if [ "$1" = "down" ] ; then
+  echo "Fake downing the docker-app in $(pwd)"
+  touch ../docker-compose-down-called
+  exit 0
+fi
 echo "Unknown command: $*"
 exit 1

--- a/src/libaktualizr/package_manager/dockerappmanager.h
+++ b/src/libaktualizr/package_manager/dockerappmanager.h
@@ -21,6 +21,7 @@ class DockerAppManager : public OstreeManager {
 
  private:
   bool iterate_apps(const Uptane::Target &target, const DockerAppCb &cb) const;
+  void handleRemovedApps() const;
 
   // iterate_apps needs an Uptane::Fetcher. However, its an unused parameter
   // and we just need to construct a dummy one to make the compiler happy.

--- a/src/libaktualizr/package_manager/packagemanagerconfig.cc
+++ b/src/libaktualizr/package_manager/packagemanagerconfig.cc
@@ -34,15 +34,14 @@ void PackageConfig::updateFromPropertyTree(const boost::property_tree::ptree& pt
   CopyFromConfig(packages_file, "packages_file", pt);
   CopyFromConfig(fake_need_reboot, "fake_need_reboot", pt);
 #ifdef BUILD_DOCKERAPP
-  std::string val;
+  CopyFromConfig(docker_apps_root, "docker_apps_root", pt);
+  CopyFromConfig(docker_compose_bin, "docker_compose_bin", pt);
   CopyFromConfig(val, "docker_apps", pt);
   if (val.length() > 0) {
     // token_compress_on allows lists like: "foo,bar", "foo, bar", or "foo bar"
     boost::split(docker_apps, val, boost::is_any_of(", "), boost::token_compress_on);
-    CopyFromConfig(docker_apps_root, "docker_apps_root", pt);
     CopyFromConfig(docker_app_params, "docker_app_params", pt);
     CopyFromConfig(docker_app_bin, "docker_app_bin", pt);
-    CopyFromConfig(docker_compose_bin, "docker_compose_bin", pt);
   }
 #endif
 }

--- a/src/libaktualizr/package_manager/packagemanagerconfig.cc
+++ b/src/libaktualizr/package_manager/packagemanagerconfig.cc
@@ -33,6 +33,12 @@ void PackageConfig::updateFromPropertyTree(const boost::property_tree::ptree& pt
   CopyFromConfig(ostree_server, "ostree_server", pt);
   CopyFromConfig(packages_file, "packages_file", pt);
   CopyFromConfig(fake_need_reboot, "fake_need_reboot", pt);
+  std::string val;
+  CopyFromConfig(val, "tags", pt);
+  if (val.length() > 0) {
+    boost::split(tags, val, boost::is_any_of(", "), boost::token_compress_on);
+    val.clear();  // this is re-used by docker_apps
+  }
 #ifdef BUILD_DOCKERAPP
   CopyFromConfig(docker_apps_root, "docker_apps_root", pt);
   CopyFromConfig(docker_compose_bin, "docker_compose_bin", pt);
@@ -53,6 +59,7 @@ void PackageConfig::writeToStream(std::ostream& out_stream) const {
   writeOption(out_stream, ostree_server, "ostree_server");
   writeOption(out_stream, packages_file, "packages_file");
   writeOption(out_stream, fake_need_reboot, "fake_need_reboot");
+  writeOption(out_stream, boost::algorithm::join(tags, ","), "tags");
 #ifdef BUILD_DOCKERAPP
   writeOption(out_stream, boost::algorithm::join(docker_apps, ","), "docker_apps");
   writeOption(out_stream, docker_apps_root, "docker_apps_root");

--- a/src/libaktualizr/package_manager/packagemanagerconfig.h
+++ b/src/libaktualizr/package_manager/packagemanagerconfig.h
@@ -16,6 +16,7 @@ struct PackageConfig {
   boost::filesystem::path sysroot;
   std::string ostree_server;
   boost::filesystem::path packages_file{"/usr/package.manifest"};
+  std::vector<std::string> tags;
 
 #ifdef BUILD_DOCKERAPP
   std::vector<std::string> docker_apps;

--- a/src/libaktualizr/primary/sotauptaneclient.cc
+++ b/src/libaktualizr/primary/sotauptaneclient.cc
@@ -186,7 +186,11 @@ data::InstallationResult SotaUptaneClient::PackageInstallSetResult(const Uptane:
 void SotaUptaneClient::reportHwInfo() {
   Json::Value hw_info = Utils::getHardwareInfo();
   if (!hw_info.empty()) {
-    http->put(config.tls.server + "/core/system_info", hw_info);
+    if (hw_info != last_hw_info_reported) {
+      if (http->put(config.tls.server + "/core/system_info", hw_info).isOk()) {
+        last_hw_info_reported = hw_info;
+      }
+    }
   } else {
     LOG_WARNING << "Unable to fetch hardware information from host system.";
   }

--- a/src/libaktualizr/primary/sotauptaneclient.h
+++ b/src/libaktualizr/primary/sotauptaneclient.h
@@ -67,6 +67,7 @@ class SotaUptaneClient {
   data::InstallationResult PackageInstall(const Uptane::Target &target);
   TargetStatus VerifyTarget(const Uptane::Target &target) { return package_manager_->verifyTarget(target); }
   void reportNetworkInfo();
+  void reportHwInfo();
 
  protected:
   void addSecondary(const std::shared_ptr<Uptane::SecondaryInterface> &sec);
@@ -112,7 +113,6 @@ class SotaUptaneClient {
                                                 const Uptane::EcuSerial &ecu_id);
   data::InstallationResult PackageInstallSetResult(const Uptane::Target &target);
   void finalizeAfterReboot();
-  void reportHwInfo();
   void reportInstalledPackages();
   void verifySecondaries();
   void sendMetadataToEcus(const std::vector<Uptane::Target> &targets);

--- a/src/libaktualizr/primary/sotauptaneclient.h
+++ b/src/libaktualizr/primary/sotauptaneclient.h
@@ -66,6 +66,7 @@ class SotaUptaneClient {
   bool checkImagesMetaOffline();
   data::InstallationResult PackageInstall(const Uptane::Target &target);
   TargetStatus VerifyTarget(const Uptane::Target &target) { return package_manager_->verifyTarget(target); }
+  void reportNetworkInfo();
 
  protected:
   void addSecondary(const std::shared_ptr<Uptane::SecondaryInterface> &sec);
@@ -113,7 +114,6 @@ class SotaUptaneClient {
   void finalizeAfterReboot();
   void reportHwInfo();
   void reportInstalledPackages();
-  void reportNetworkInfo();
   void verifySecondaries();
   void sendMetadataToEcus(const std::vector<Uptane::Target> &targets);
   std::future<bool> sendFirmwareAsync(Uptane::SecondaryInterface &secondary, const std::shared_ptr<std::string> &data);

--- a/src/libaktualizr/primary/sotauptaneclient.h
+++ b/src/libaktualizr/primary/sotauptaneclient.h
@@ -151,6 +151,7 @@ class SotaUptaneClient {
   std::shared_ptr<Bootloader> bootloader;
   std::shared_ptr<ReportQueue> report_queue;
   Json::Value last_network_info_reported;
+  Json::Value last_hw_info_reported;
   Uptane::EcuMap hw_ids;
   std::shared_ptr<event::Channel> events_channel;
   boost::signals2::connection conn;

--- a/src/libaktualizr/utilities/config_utils.h
+++ b/src/libaktualizr/utilities/config_utils.h
@@ -164,7 +164,8 @@ class BaseConfig {
     }
   }
 
-  std::vector<boost::filesystem::path> config_dirs_ = {"/usr/lib/sota/conf.d", "/etc/sota/conf.d/"};
+  std::vector<boost::filesystem::path> config_dirs_ = {"/usr/lib/sota/conf.d", "/var/sota/sota.toml",
+                                                       "/etc/sota/conf.d/"};
 };
 
 #endif  // CONFIG_UTILS_H_


### PR DESCRIPTION
This puts us on the 2019.9 tag of Aktualizr. Several of our patches have been merged that we are now able to drop. Other notable changes:

1. I've tried to move most of our "toup" patches to the beginning of the branch so its easy to see what we need to start pushing upstream.
1. I squashed all our "fixup" patches with their offending commits.
1. I squashed the uptane interval fix from 2019.8+fio with the "Add a daemon mode" patch.

This leaves us 4 patches we need to work on upstreaming  11 "fio extras" patches.

This branch builds cleanly (also "ninja formats" cleanly). I'm in the process of doing some manual testing.