### PR TITLE
[fio toup] packagemanager: Run docker-prune after installs

### DIFF
--- a/src/libaktualizr/package_manager/dockerappmanager.cc
+++ b/src/libaktualizr/package_manager/dockerappmanager.cc
@@ -152,7 +152,15 @@ data::InstallationResult DockerAppManager::install(const Uptane::Target &target)
     return dapp.render(ss.str(), true) && dapp.start();
   };
   if (!iterate_apps(target, cb)) {
-    return data::InstallationResult(data::ResultCode::Numeric::kInstallFailed, "Could not render docker app");
+    res = data::InstallationResult(data::ResultCode::Numeric::kInstallFailed, "Could not render docker app");
+  }
+  if (config.docker_prune) {
+    LOG_INFO << "Pruning old docker artifacts";
+    // Utils::shell which isn't interactive, we'll use std::system so that
+    // stdout/stderr is streamed while docker sets things up.
+    if (std::system("docker system prune -f") != 0) {
+      LOG_WARNING << "Unable to prune old docker artifacts";
+    }
   }
   return res;
 }

--- a/src/libaktualizr/package_manager/dockerappmanager_test.cc
+++ b/src/libaktualizr/package_manager/dockerappmanager_test.cc
@@ -72,6 +72,7 @@ TEST(DockerAppManager, DockerApp_Fetch) {
   config.pacman.docker_apps_root = temp_dir / "docker_apps";
   config.pacman.docker_apps.push_back("app1");
   config.pacman.docker_app_bin = config.pacman.docker_compose_bin = "src/libaktualizr/package_manager/docker_fake.sh";
+  config.pacman.docker_prune = false;
   config.pacman.ostree_server = treehub_server;
   config.uptane.repo_server = repo_server + "/repo/repo";
   TemporaryDirectory dir;

--- a/src/libaktualizr/package_manager/packagemanagerconfig.cc
+++ b/src/libaktualizr/package_manager/packagemanagerconfig.cc
@@ -42,6 +42,7 @@ void PackageConfig::updateFromPropertyTree(const boost::property_tree::ptree& pt
 #ifdef BUILD_DOCKERAPP
   CopyFromConfig(docker_apps_root, "docker_apps_root", pt);
   CopyFromConfig(docker_compose_bin, "docker_compose_bin", pt);
+  CopyFromConfig(docker_prune, "docker_prune", pt);
   CopyFromConfig(val, "docker_apps", pt);
   if (val.length() > 0) {
     // token_compress_on allows lists like: "foo,bar", "foo, bar", or "foo bar"
@@ -66,5 +67,6 @@ void PackageConfig::writeToStream(std::ostream& out_stream) const {
   writeOption(out_stream, docker_app_params, "docker_app_params");
   writeOption(out_stream, docker_app_bin, "docker_app_bin");
   writeOption(out_stream, docker_compose_bin, "docker_compose_bin");
+  writeOption(out_stream, docker_prune, "docker_prune");
 #endif
 }

--- a/src/libaktualizr/package_manager/packagemanagerconfig.h
+++ b/src/libaktualizr/package_manager/packagemanagerconfig.h
@@ -24,6 +24,7 @@ struct PackageConfig {
   boost::filesystem::path docker_app_params;
   boost::filesystem::path docker_app_bin{"/usr/bin/docker-app"};
   boost::filesystem::path docker_compose_bin{"/usr/bin/docker-compose"};
+  bool docker_prune{true};
 #endif
 
   // Options for simulation (to be used with kNone)


### PR DESCRIPTION
Docker builds up old images and volues over time consuming disk space.
This is normally not what you want for a managed device.

Signed-off-by: Andy Doan <andy@foundries.io>