### PR TITLE
[FIO toup] sig_handler: prefer atomic_uint instead of atomic<bool>

### DIFF
--- a/src/libaktualizr/utilities/sig_handler.cc
+++ b/src/libaktualizr/utilities/sig_handler.cc
@@ -1,7 +1,7 @@
 #include "sig_handler.h"
 #include "logging/logging.h"
 
-std::atomic<bool> SigHandler::signal_marker_;
+std::atomic_uint SigHandler::signal_marker_;
 std::mutex SigHandler::exit_m_;
 std::condition_variable SigHandler::exit_cv_;
 bool SigHandler::exit_flag_;
@@ -31,7 +31,7 @@ void SigHandler::start(const std::function<void()>& on_signal) {
   polling_thread_ = boost::thread([on_signal]() {
     std::unique_lock<std::mutex> l(exit_m_);
     while (true) {
-      bool got_signal = signal_marker_.exchange(false);
+      auto got_signal = signal_marker_.exchange(0);
 
       if (got_signal) {
         on_signal();
@@ -49,7 +49,7 @@ void SigHandler::signal(int sig) { ::signal(sig, signal_handler); }
 
 void SigHandler::signal_handler(int sig) {
   (void)sig;
-  bool v = false;
+  unsigned int v = 0;
   // put true if currently set to false
-  SigHandler::signal_marker_.compare_exchange_strong(v, true);
+  SigHandler::signal_marker_.compare_exchange_strong(v, 1);
 }

--- a/src/libaktualizr/utilities/sig_handler.h
+++ b/src/libaktualizr/utilities/sig_handler.h
@@ -31,7 +31,7 @@ class SigHandler {
   static void signal_handler(int sig);
 
   boost::thread polling_thread_;
-  static std::atomic<bool> signal_marker_;
+  static std::atomic_uint signal_marker_;
 
   static std::mutex exit_m_;
   static std::condition_variable exit_cv_;


### PR DESCRIPTION
Atomic<bool> operations are not available on GCC 9.2 when building for
RISC-V, causing a build failure. Switch to atomic_uint as that is known
to be provided by GCC in order to avoid the failure.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>