### PR TITLE
[fio noup] aktualizr-lite: Fix bad daemon logic

### DIFF
--- a/src/aktualizr_lite/main.cc
+++ b/src/aktualizr_lite/main.cc
@@ -236,7 +236,9 @@ static int daemon_main(LiteClient &client, const bpo::variables_map &variables_m
   while (true) {
     LOG_INFO << "Refreshing target metadata";
     if (!client.primary->updateImagesMeta()) {
-      LOG_WARNING << "Unable to update latest metadata, using local copy";
+      LOG_WARNING << "Unable to update latest metadata";
+      std::this_thread::sleep_for(std::chrono::seconds(interval));
+      continue;  // There's no point trying to look for an update
     }
 
     client.primary->reportNetworkInfo();


### PR DESCRIPTION
This has been a common complaint for a while now. If we are unable
to check the contents of the lates metadata, then we should not look
for updates to install (there won't be any).

Signed-off-by: Andy Doan <andy@foundries.io>