### PR TITLE
[fio toup] packagemanager: fix-up docker prune commands

### DIFF
--- a/src/libaktualizr/package_manager/dockerappmanager.cc
+++ b/src/libaktualizr/package_manager/dockerappmanager.cc
@@ -155,11 +155,11 @@ data::InstallationResult DockerAppManager::install(const Uptane::Target &target)
     res = data::InstallationResult(data::ResultCode::Numeric::kInstallFailed, "Could not render docker app");
   }
   if (config.docker_prune) {
-    LOG_INFO << "Pruning old docker artifacts";
+    LOG_INFO << "Pruning unused docker images";
     // Utils::shell which isn't interactive, we'll use std::system so that
     // stdout/stderr is streamed while docker sets things up.
-    if (std::system("docker system prune -f") != 0) {
-      LOG_WARNING << "Unable to prune old docker artifacts";
+    if (std::system("docker image prune -a -f") != 0) {
+      LOG_WARNING << "Unable to prune unused docker images";
     }
   }
   return res;


### PR DESCRIPTION
- when running non-interactive docker prune commands use -f
- split docker system prune into: container prune and image prune
  this way we are sure not delete volume and network data

Signed-off-by: Michael Scott <mike@foundries.io>