### PR TITLE
ak-lite: add rollback support

### DIFF
--- a/src/aktualizr_lite/helpers.h
+++ b/src/aktualizr_lite/helpers.h
@@ -21,6 +21,7 @@ struct LiteClient {
   Config config;
   std::shared_ptr<INvStorage> storage;
   std::shared_ptr<SotaUptaneClient> primary;
+  std::shared_ptr<PackageManagerInterface> package_manager;
   std::unique_ptr<ReportQueue> report_queue;
   std::shared_ptr<HttpClient> http_client;
   Uptane::EcuSerial primary_serial;

--- a/src/aktualizr_lite/helpers.h
+++ b/src/aktualizr_lite/helpers.h
@@ -37,5 +37,6 @@ struct LiteClient {
 void generate_correlation_id(Uptane::Target& t);
 bool target_has_tags(const Uptane::Target& t, const std::vector<std::string>& config_tags);
 bool targets_eq(const Uptane::Target& t1, const Uptane::Target& t2, bool compareDockerApps);
+bool known_local_target(LiteClient &client, const Uptane::Target &t, std::vector<Uptane::Target> &installed_versions);
 
 #endif  // AKTUALIZR_LITE_HELPERS

--- a/src/libaktualizr/package_manager/dockerappmanager.cc
+++ b/src/libaktualizr/package_manager/dockerappmanager.cc
@@ -145,6 +145,11 @@ data::InstallationResult DockerAppManager::install(const Uptane::Target &target)
   data::InstallationResult res;
   Uptane::Target current = OstreeManager::getCurrent();
   if (current.sha256Hash() != target.sha256Hash()) {
+    // notify the bootloader before installation happens as it is not atomic
+    // and a false notification doesn't hurt with rollback support in place
+    if (bootloader_ != nullptr) {
+      bootloader_->updateNotify();
+    }
     res = OstreeManager::install(target);
     if (res.result_code.num_code == data::ResultCode::Numeric::kInstallFailed) {
       LOG_ERROR << "Failed to install OSTree target, skipping Docker Apps";


### PR DESCRIPTION
Tested scenarios (on a rpi3-64):
1 - Update in daemon mode
2 - Update via update command (to a newer rev, after update applied and after reboot)
3 - Rollback process in daemon mode
4 - Forced update after a rollback (protection is only done in daemon mode)
5 - Base image rollback with with docker app
6 - Docker app updates after a rollback
7 - Docker app updates with update
8 - Docker app updates with daemon
9 - Base image + docker app updates

To test the rollback support you will have to flash an image produced by the https://github.com/foundriesio/lmp-manifest/pull/48 pull request (build 734 uses my aktualizr branch so no need to build it by hand). This is required because we also need u-boot script updates, which is not yet managed by ostree.

The easiest way to trigger a rollback is to call aktualizr-lite update and remove the new kernel from the /boot directory, as then u-boot will fail to boot the new image and rollback to the previous one, like:
```
aktualizr-lite --command update
# Check the lmp-hash used by looking at the first kernel_image entry at /boot/loader/uEnv.txt
cd /boot/
sudo mv ./ostree/lmp-1f3c7bbb8edc3c407c968565a8d26162cb617d07dbfe86f26795670193814d4f/vmlinuz ./ostree/lmp-1f3c7bbb8edc3c407c968565a8d26162cb617d07dbfe86f26795670193814d4f/vmlinuz-orig
sudo touch ./ostree/lmp-1f3c7bbb8edc3c407c968565a8d26162cb617d07dbfe86f26795670193814d4f/vmlinuz
```

Then if you start ak-lite in daemon mode you will see that it will refuse to update as the image is known to be bad. Forcing via update command will still work, but you might have to move the vmlinuz-orig back as it looks like a new ostree deployment won't refresh that file.