### PR TITLE
[fio extras] bootloader: add support to fio verified boot

### DIFF
--- a/src/libaktualizr/bootloader/bootloader.cc
+++ b/src/libaktualizr/bootloader/bootloader.cc
@@ -41,6 +41,11 @@ void Bootloader::setBootOK() const {
         LOG_WARNING << "Failed resetting upgrade_available for u-boot";
       }
       break;
+    case RollbackMode::kFioVB:
+      if (Utils::shell("fiovb_setenv bootcount 0", &sink) != 0) {
+        LOG_WARNING << "Failed resetting bootcount";
+      }
+      break;
     default:
       throw NotImplementedException();
   }
@@ -67,6 +72,14 @@ void Bootloader::updateNotify() const {
         LOG_WARNING << "Failed setting upgrade_available for u-boot";
       }
       if (Utils::shell("fw_setenv rollback 0", &sink) != 0) {
+        LOG_WARNING << "Failed resetting rollback flag";
+      }
+      break;
+    case RollbackMode::kFioVB:
+      if (Utils::shell("fiovb_setenv bootcount 0", &sink) != 0) {
+        LOG_WARNING << "Failed resetting bootcount";
+      }
+      if (Utils::shell("fiovb_setenv rollback 0", &sink) != 0) {
         LOG_WARNING << "Failed resetting rollback flag";
       }
       break;

--- a/src/libaktualizr/bootloader/bootloader_config.cc
+++ b/src/libaktualizr/bootloader/bootloader_config.cc
@@ -10,6 +10,9 @@ std::ostream& operator<<(std::ostream& os, RollbackMode mode) {
     case RollbackMode::kUbootMasked:
       mode_s = "uboot_masked";
       break;
+    case RollbackMode::kFioVB:
+      mode_s = "fiovb";
+      break;
     default:
       mode_s = "none";
       break;
@@ -27,6 +30,8 @@ inline void CopyFromConfig(RollbackMode& dest, const std::string& option_name, c
       dest = RollbackMode::kUbootGeneric;
     } else if (mode == "uboot_masked") {
       dest = RollbackMode::kUbootMasked;
+    } else if (mode == "fiovb") {
+      dest = RollbackMode::kFioVB;
     } else {
       dest = RollbackMode::kBootloaderNone;
     }

--- a/src/libaktualizr/bootloader/bootloader_config.h
+++ b/src/libaktualizr/bootloader/bootloader_config.h
@@ -5,7 +5,7 @@
 #include <boost/property_tree/ini_parser.hpp>
 #include <ostream>
 
-enum class RollbackMode { kBootloaderNone = 0, kUbootGeneric, kUbootMasked };
+enum class RollbackMode { kBootloaderNone = 0, kUbootGeneric, kUbootMasked, kFioVB };
 std::ostream& operator<<(std::ostream& os, RollbackMode mode);
 
 struct BootloaderConfig {


### PR DESCRIPTION
Add support for Foundries.io verified boot, which uses OP-TEE for
storing the bootloader variables such as bootcount and rollback.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>