### PR TITLE
[fio fromlist] docker-app: Fix bad parameters file logic

### DIFF
--- a/src/libaktualizr/package_manager/dockerappmanager.cc
+++ b/src/libaktualizr/package_manager/dockerappmanager.cc
@@ -50,7 +50,7 @@ struct DockerApp {
     Utils::writeFile(app_root / (name + ".dockerapp"), app_content);
     std::string cmd("cd " + app_root.string() + " && " + bin + " render " + name);
     if (!app_params.empty()) {
-      cmd += " -f " + app_params.string();
+      cmd += " --parameters-file " + app_params.string();
     }
     std::string yaml;
     if (Utils::shell(cmd, &yaml, true) != 0) {


### PR DESCRIPTION
docker-app was changed between the original testing in 0.6 and the
current 0.8 to not accept the short-hand argument for the parameters
file. This change uses the long for which is easier to read and
"just works".

Signed-off-by: Andy Doan <andy@foundries.io>