### PR TITLE
[fio extras] aktualizr-lite: Track anonymous usage

### DIFF
--- a/src/aktualizr_lite/helpers.cc
+++ b/src/aktualizr_lite/helpers.cc
@@ -106,6 +106,12 @@ LiteClient::LiteClient(Config &config_in) : config(std::move(config_in)), primar
   headers.push_back(header);
   add_apps_header(headers, config.pacman);
 
+  if (!config.telemetry.report_network) {
+    // Provide the random primary ECU serial so our backend will have some
+    // idea of the number of unique devices using the system
+    headers.emplace_back("x-ats-primary: " + primary_serial.ToString());
+  }
+
   headers.emplace_back("x-ats-target: unknown");
   headers.emplace_back("x-ats-tags: " + boost::algorithm::join(config.pacman.tags, ","));
   http_client = std::make_shared<HttpClient>(&headers);


### PR DESCRIPTION
In the event the device isn't talking to a TLS server, then we know
the device is running our public LMP. This allows us to have some
idea of the number of unique devices using the system.

Signed-off-by: Andy Doan <andy@foundries.io>