### PR TITLE
[fio extras] aktualizr-lite: Detect docker-app config changes

### DIFF
--- a/src/aktualizr_lite/helpers.cc
+++ b/src/aktualizr_lite/helpers.cc
@@ -161,6 +161,64 @@ void LiteClient::notifyInstallFinished(const Uptane::Target &t, data::ResultCode
   }
 }
 
+void LiteClient::storeDockerParamsDigest() {
+  auto digest = config.storage.path / ".params-hash";
+  if (boost::filesystem::exists(config.pacman.docker_app_params)) {
+    Utils::writeFile(digest, Crypto::sha256digest(Utils::readFile(config.pacman.docker_app_params)));
+  } else {
+    unlink(digest.c_str());
+  }
+}
+
+bool LiteClient::dockerAppsChanged() {
+  if (config.pacman.type != PackageManager::kOstreeDockerApp) {
+    return false;
+  }
+
+  // Did the list of installed versus running apps change:
+  std::vector<std::string> found;
+  if (boost::filesystem::is_directory(config.pacman.docker_apps_root)) {
+    for (auto &entry :
+         boost::make_iterator_range(boost::filesystem::directory_iterator(config.pacman.docker_apps_root), {})) {
+      if (boost::filesystem::is_directory(entry)) {
+        found.emplace_back(entry.path().filename().native());
+      }
+    }
+  }
+  std::sort(found.begin(), found.end());
+  std::sort(config.pacman.docker_apps.begin(), config.pacman.docker_apps.end());
+  if (found != config.pacman.docker_apps) {
+    LOG_INFO << "Config change detected: list of apps has changed";
+    return true;
+  }
+
+  // Did the docker app configuration change
+  auto checksum = config.storage.path / ".params-hash";
+  if (boost::filesystem::exists(config.pacman.docker_app_params)) {
+    if (config.pacman.docker_apps.size() == 0) {
+      // there's no point checking for changes - nothing is running
+      return false;
+    }
+
+    if (boost::filesystem::exists(checksum)) {
+      std::string cur = Utils::readFile(checksum);
+      std::string now = Crypto::sha256digest(Utils::readFile(config.pacman.docker_app_params));
+      if (cur != now) {
+        LOG_INFO << "Config change detected: docker-app-params content has changed";
+        return true;
+      }
+    } else {
+      LOG_INFO << "Config change detected: docker-app-params have been defined";
+      return true;
+    }
+  } else if (boost::filesystem::exists(checksum)) {
+    LOG_INFO << "Config change detected: docker-app parameters have been removed";
+    return true;
+  }
+
+  return false;
+}
+
 void generate_correlation_id(Uptane::Target &t) {
   std::string id = t.custom_version();
   if (id.empty()) {

--- a/src/aktualizr_lite/helpers.h
+++ b/src/aktualizr_lite/helpers.h
@@ -32,6 +32,8 @@ struct LiteClient {
   void notifyInstallFinished(const Uptane::Target& t, data::ResultCode::Numeric rc);
 
   void notify(const Uptane::Target& t, std::unique_ptr<ReportEvent> event);
+  bool dockerAppsChanged();
+  void storeDockerParamsDigest();
 };
 
 void generate_correlation_id(Uptane::Target& t);

--- a/src/aktualizr_lite/helpers_test.cc
+++ b/src/aktualizr_lite/helpers_test.cc
@@ -123,6 +123,62 @@ TEST(helpers, targets_eq) {
   ASSERT_TRUE(targets_eq(t1, t2, true));
 }
 
+// Ensure we handle config changes of containers at start-up properly
+TEST(helpers, containers_initialize) {
+  TemporaryDirectory cfg_dir;
+
+  Config config;
+  config.storage.path = cfg_dir.Path();
+  config.pacman.type = PackageManager::kOstreeDockerApp;
+  config.pacman.sysroot = test_sysroot;
+  config.pacman.docker_apps_root = cfg_dir / "docker_apps";
+
+  std::shared_ptr<INvStorage> storage = INvStorage::newStorage(config.storage);
+
+  Json::Value target_json;
+  target_json["hashes"]["sha256"] = "deadbeef";
+  target_json["custom"]["targetFormat"] = "OSTREE";
+  target_json["length"] = 0;
+  Uptane::Target target("test-finalize", target_json);
+
+  LiteClient client(config);
+
+  // Nothing different - all empty
+  ASSERT_FALSE(client.dockerAppsChanged());
+
+  // Add a new app
+  client.config.pacman.docker_apps.push_back("app1");
+  ASSERT_TRUE(client.dockerAppsChanged());
+
+  // No apps configured, but one installed:
+  client.config.pacman.docker_apps.clear();
+  boost::filesystem::create_directories(client.config.pacman.docker_apps_root / "app1");
+  ASSERT_TRUE(client.dockerAppsChanged());
+
+  // One app configured, one app deployed
+  client.config.pacman.docker_apps.push_back("app1");
+  boost::filesystem::create_directories(client.config.pacman.docker_apps_root / "app1");
+  ASSERT_FALSE(client.dockerAppsChanged());
+
+  // Docker app parameters enabled
+  client.config.pacman.docker_app_params = cfg_dir / "foo.txt";
+  Utils::writeFile(client.config.pacman.docker_app_params, std::string("foo text content"));
+  ASSERT_TRUE(client.dockerAppsChanged());
+
+  // Store the hash of the file and make sure no change is detected
+  client.storeDockerParamsDigest();
+  ASSERT_FALSE(client.dockerAppsChanged());
+
+  // Change the content
+  Utils::writeFile(client.config.pacman.docker_app_params, std::string("foo text content changed"));
+  ASSERT_TRUE(client.dockerAppsChanged());
+
+  // Disable and ensure we detect the change
+  client.config.pacman.docker_app_params = "";
+  ASSERT_TRUE(client.dockerAppsChanged());
+  ASSERT_FALSE(boost::filesystem::exists(config.storage.path / ".params-hash"));
+}
+
 #ifndef __NO_MAIN__
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);

--- a/src/aktualizr_lite/main.cc
+++ b/src/aktualizr_lite/main.cc
@@ -217,6 +217,14 @@ static int daemon_main(LiteClient &client, const bpo::variables_map &variables_m
   auto current = client.primary->getCurrent();
   LOG_INFO << "Active image is: " << current;
 
+  if (!current.MatchTarget(Uptane::Target::Unknown()) && client.dockerAppsChanged()) {
+    data::InstallationResult rc = client.package_manager->install(current);
+    if (!rc.isSuccess()) {
+      LOG_ERROR << "Unable to apply docker-app config changes: " << rc.description;
+    }
+  }
+  client.storeDockerParamsDigest();
+
   uint64_t interval = client.config.uptane.polling_sec;
   if (variables_map.count("interval") > 0) {
     interval = variables_map["interval"].as<uint64_t>();


### PR DESCRIPTION
A common stumbling block people hit with aktualizr-lite is with
changing their docker-apps (or just enabling the first one). They
assume that by changing the config and restarting the daemon, that
the new changes will take place.

This changes detects such a change and will force an install of the
current target which will cause those changes to take place.

Signed-off-by: Andy Doan <andy@foundries.io>