### PR TITLE
Docker app config fixes

### DIFF
--- a/src/aktualizr_lite/helpers.cc
+++ b/src/aktualizr_lite/helpers.cc
@@ -12,9 +12,75 @@ static void add_apps_header(std::vector<std::string> &headers, PackageConfig &co
     headers.emplace_back("x-ats-dockerapps: " + boost::algorithm::join(config.docker_apps, ","));
   }
 }
-#else
+bool should_compare_docker_apps(const Config &config) {
+  return (config.pacman.type == PackageManager::kOstreeDockerApp && !config.pacman.docker_apps.empty());
+}
+
+void LiteClient::storeDockerParamsDigest() {
+  auto digest = config.storage.path / ".params-hash";
+  if (boost::filesystem::exists(config.pacman.docker_app_params)) {
+    Utils::writeFile(digest, Crypto::sha256digest(Utils::readFile(config.pacman.docker_app_params)));
+  } else {
+    unlink(digest.c_str());
+  }
+}
+
+bool LiteClient::dockerAppsChanged() {
+  if (config.pacman.type != PackageManager::kOstreeDockerApp) {
+    return false;
+  }
+
+  // Did the list of installed versus running apps change:
+  std::vector<std::string> found;
+  if (boost::filesystem::is_directory(config.pacman.docker_apps_root)) {
+    for (auto &entry :
+         boost::make_iterator_range(boost::filesystem::directory_iterator(config.pacman.docker_apps_root), {})) {
+      if (boost::filesystem::is_directory(entry)) {
+        found.emplace_back(entry.path().filename().native());
+      }
+    }
+  }
+  std::sort(found.begin(), found.end());
+  std::sort(config.pacman.docker_apps.begin(), config.pacman.docker_apps.end());
+  if (found != config.pacman.docker_apps) {
+    LOG_INFO << "Config change detected: list of apps has changed";
+    return true;
+  }
+
+  // Did the docker app configuration change
+  auto checksum = config.storage.path / ".params-hash";
+  if (boost::filesystem::exists(config.pacman.docker_app_params)) {
+    if (config.pacman.docker_apps.size() == 0) {
+      // there's no point checking for changes - nothing is running
+      return false;
+    }
+
+    if (boost::filesystem::exists(checksum)) {
+      std::string cur = Utils::readFile(checksum);
+      std::string now = Crypto::sha256digest(Utils::readFile(config.pacman.docker_app_params));
+      if (cur != now) {
+        LOG_INFO << "Config change detected: docker-app-params content has changed";
+        return true;
+      }
+    } else {
+      LOG_INFO << "Config change detected: docker-app-params have been defined";
+      return true;
+    }
+  } else if (boost::filesystem::exists(checksum)) {
+    LOG_INFO << "Config change detected: docker-app parameters have been removed";
+    return true;
+  }
+
+  return false;
+}
+#else /* ! BUILD_DOCKERAPP */
 #define add_apps_header(headers, config) \
   {}
+
+bool should_compare_docker_apps(const Config &config){return false};
+
+void LiteClient::storeDockerParamsDigest() {}
+bool LiteClient::dockerAppsChanged() { return false; }
 #endif
 
 static std::pair<Uptane::Target, data::ResultCode::Numeric> finalizeIfNeeded(PackageManagerInterface &package_manager,
@@ -159,64 +225,6 @@ void LiteClient::notifyInstallFinished(const Uptane::Target &t, data::ResultCode
   } else {
     notify(t, std_::make_unique<EcuInstallationCompletedReport>(primary_serial, t.correlation_id(), false));
   }
-}
-
-void LiteClient::storeDockerParamsDigest() {
-  auto digest = config.storage.path / ".params-hash";
-  if (boost::filesystem::exists(config.pacman.docker_app_params)) {
-    Utils::writeFile(digest, Crypto::sha256digest(Utils::readFile(config.pacman.docker_app_params)));
-  } else {
-    unlink(digest.c_str());
-  }
-}
-
-bool LiteClient::dockerAppsChanged() {
-  if (config.pacman.type != PackageManager::kOstreeDockerApp) {
-    return false;
-  }
-
-  // Did the list of installed versus running apps change:
-  std::vector<std::string> found;
-  if (boost::filesystem::is_directory(config.pacman.docker_apps_root)) {
-    for (auto &entry :
-         boost::make_iterator_range(boost::filesystem::directory_iterator(config.pacman.docker_apps_root), {})) {
-      if (boost::filesystem::is_directory(entry)) {
-        found.emplace_back(entry.path().filename().native());
-      }
-    }
-  }
-  std::sort(found.begin(), found.end());
-  std::sort(config.pacman.docker_apps.begin(), config.pacman.docker_apps.end());
-  if (found != config.pacman.docker_apps) {
-    LOG_INFO << "Config change detected: list of apps has changed";
-    return true;
-  }
-
-  // Did the docker app configuration change
-  auto checksum = config.storage.path / ".params-hash";
-  if (boost::filesystem::exists(config.pacman.docker_app_params)) {
-    if (config.pacman.docker_apps.size() == 0) {
-      // there's no point checking for changes - nothing is running
-      return false;
-    }
-
-    if (boost::filesystem::exists(checksum)) {
-      std::string cur = Utils::readFile(checksum);
-      std::string now = Crypto::sha256digest(Utils::readFile(config.pacman.docker_app_params));
-      if (cur != now) {
-        LOG_INFO << "Config change detected: docker-app-params content has changed";
-        return true;
-      }
-    } else {
-      LOG_INFO << "Config change detected: docker-app-params have been defined";
-      return true;
-    }
-  } else if (boost::filesystem::exists(checksum)) {
-    LOG_INFO << "Config change detected: docker-app parameters have been removed";
-    return true;
-  }
-
-  return false;
 }
 
 void generate_correlation_id(Uptane::Target &t) {

--- a/src/aktualizr_lite/helpers.h
+++ b/src/aktualizr_lite/helpers.h
@@ -36,6 +36,7 @@ struct LiteClient {
   void storeDockerParamsDigest();
 };
 
+bool should_compare_docker_apps(const Config& config);
 void generate_correlation_id(Uptane::Target& t);
 bool target_has_tags(const Uptane::Target& t, const std::vector<std::string>& config_tags);
 bool targets_eq(const Uptane::Target& t1, const Uptane::Target& t2, bool compareDockerApps);

--- a/src/aktualizr_lite/helpers_test.cc
+++ b/src/aktualizr_lite/helpers_test.cc
@@ -123,6 +123,7 @@ TEST(helpers, targets_eq) {
   ASSERT_TRUE(targets_eq(t1, t2, true));
 }
 
+#ifdef BUILD_DOCKERAPP
 // Ensure we handle config changes of containers at start-up properly
 TEST(helpers, containers_initialize) {
   TemporaryDirectory cfg_dir;
@@ -178,6 +179,7 @@ TEST(helpers, containers_initialize) {
   ASSERT_TRUE(client.dockerAppsChanged());
   ASSERT_FALSE(boost::filesystem::exists(config.storage.path / ".params-hash"));
 }
+#endif
 
 #ifndef __NO_MAIN__
 int main(int argc, char **argv) {

--- a/src/aktualizr_lite/main.cc
+++ b/src/aktualizr_lite/main.cc
@@ -218,10 +218,7 @@ static int daemon_main(LiteClient &client, const bpo::variables_map &variables_m
   LOG_INFO << "Active image is: " << current;
 
   if (!current.MatchTarget(Uptane::Target::Unknown()) && client.dockerAppsChanged()) {
-    data::InstallationResult rc = client.package_manager->install(current);
-    if (!rc.isSuccess()) {
-      LOG_ERROR << "Unable to apply docker-app config changes: " << rc.description;
-    }
+    do_update(client, current, lockfile);
   }
   client.storeDockerParamsDigest();
 

--- a/src/aktualizr_lite/main.cc
+++ b/src/aktualizr_lite/main.cc
@@ -12,13 +12,6 @@
 
 namespace bpo = boost::program_options;
 
-#ifdef BUILD_DOCKERAPP
-#define should_compare_docker_apps(config) \
-  (config.pacman.type == PackageManager::kOstreeDockerApp && !config.pacman.docker_apps.empty())
-#else
-#define should_compare_docker_apps(config) (false)
-#endif
-
 static void log_info_target(const std::string &prefix, const Config &config, const Uptane::Target &t) {
   auto name = t.filename();
   if (t.custom_version().length() > 0) {


### PR DESCRIPTION
This should fix the risc-v build break ricardo hit and the missing download operation tyler noticed.

The new "do_update" approach is actually a lot better than what I have. It goes through the path using the lockfile which people will want control over and it also will cause report events to go to the server, so we'll have some auditing to know the update took place.