### PR TITLE
2019.11+fio

### DIFF
--- a/src/aktualizr_lite/helpers.cc
+++ b/src/aktualizr_lite/helpers.cc
@@ -5,24 +5,51 @@
 
 #include "package_manager/ostreemanager.h"
 
-static void finalizeIfNeeded(INvStorage &storage, PackageConfig &config) {
+#ifdef BUILD_DOCKERAPP
+static void add_apps_header(std::vector<std::string> &headers, PackageConfig &config) {
+  if (config.type == PackageManager::kOstreeDockerApp) {
+    headers.emplace_back("x-ats-dockerapps: " + boost::algorithm::join(config.docker_apps, ","));
+  }
+}
+#else
+#define add_apps_header(headers, config) \
+  {}
+#endif
+
+static Uptane::Target finalizeIfNeeded(INvStorage &storage, PackageConfig &config) {
   boost::optional<Uptane::Target> pending_version;
   storage.loadInstalledVersions("", nullptr, &pending_version);
 
-  if (!!pending_version) {
-    GObjectUniquePtr<OstreeSysroot> sysroot_smart = OstreeManager::LoadSysroot(config.sysroot);
-    OstreeDeployment *booted_deployment = ostree_sysroot_get_booted_deployment(sysroot_smart.get());
-    if (booted_deployment == nullptr) {
-      throw std::runtime_error("Could not get booted deployment in " + config.sysroot.string());
-    }
-    std::string current_hash = ostree_deployment_get_csum(booted_deployment);
+  GObjectUniquePtr<OstreeSysroot> sysroot_smart = OstreeManager::LoadSysroot(config.sysroot);
+  OstreeDeployment *booted_deployment = ostree_sysroot_get_booted_deployment(sysroot_smart.get());
+  std::string current_hash = ostree_deployment_get_csum(booted_deployment);
+  if (booted_deployment == nullptr) {
+    throw std::runtime_error("Could not get booted deployment in " + config.sysroot.string());
+  }
 
+  if (!!pending_version) {
     const Uptane::Target &target = *pending_version;
     if (current_hash == target.sha256Hash()) {
       LOG_INFO << "Marking target install complete for: " << target;
       storage.saveInstalledVersion("", target, InstalledVersionUpdateMode::kCurrent);
+      return target;
     }
   }
+
+  std::vector<Uptane::Target> installed_versions;
+  storage.loadPrimaryInstallationLog(&installed_versions, false);
+
+  // Version should be in installed versions. Its possible that multiple
+  // targets could have the same sha256Hash. In this case the safest assumption
+  // is that the most recent (the reverse of the vector) target is what we
+  // should return.
+  std::vector<Uptane::Target>::reverse_iterator it;
+  for (it = installed_versions.rbegin(); it != installed_versions.rend(); it++) {
+    if (it->sha256Hash() == current_hash) {
+      return *it;
+    }
+  }
+  return Uptane::Target::Unknown();
 }
 
 LiteClient::LiteClient(Config &config_in) : config(std::move(config_in)) {
@@ -46,13 +73,28 @@ LiteClient::LiteClient(Config &config_in) : config(std::move(config_in)) {
     storage->storeEcuSerials(ecu_serials);
   }
 
-  auto http_client = std::make_shared<HttpClient>();
+  std::vector<std::string> headers;
+  GObjectUniquePtr<OstreeSysroot> sysroot_smart = OstreeManager::LoadSysroot(config.pacman.sysroot);
+  OstreeDeployment *deployment = ostree_sysroot_get_booted_deployment(sysroot_smart.get());
+  std::string header("x-ats-ostreehash: ");
+  if (deployment != nullptr) {
+    header += ostree_deployment_get_csum(deployment);
+  } else {
+    header += "?";
+  }
+  headers.push_back(header);
+  add_apps_header(headers, config.pacman);
+
+  Uptane::Target tgt = finalizeIfNeeded(*storage, config.pacman);
+  headers.emplace_back("x-ats-target: " + tgt.filename());
+  headers.emplace_back("x-ats-tags: " + boost::algorithm::join(config.pacman.tags, ","));
+
+  auto http_client = std::make_shared<HttpClient>(&headers);
 
   KeyManager keys(storage, config.keymanagerConfig());
   keys.copyCertsToCurl(*http_client);
 
   primary = std::make_shared<SotaUptaneClient>(config, storage, http_client);
-  finalizeIfNeeded(*storage, config.pacman);
 }
 
 bool target_has_tags(const Uptane::Target &t, const std::vector<std::string> &config_tags) {

--- a/src/aktualizr_lite/helpers.cc
+++ b/src/aktualizr_lite/helpers.cc
@@ -54,3 +54,17 @@ LiteClient::LiteClient(Config &config_in) : config(std::move(config_in)) {
   primary = std::make_shared<SotaUptaneClient>(config, storage, http_client);
   finalizeIfNeeded(*storage, config.pacman);
 }
+
+bool target_has_tags(const Uptane::Target &t, const std::vector<std::string> &config_tags) {
+  if (!config_tags.empty()) {
+    auto tags = t.custom_data()["tags"];
+    for (Json::ValueIterator i = tags.begin(); i != tags.end(); ++i) {
+      auto tag = (*i).asString();
+      if (std::find(config_tags.begin(), config_tags.end(), tag) != config_tags.end()) {
+        return true;
+      }
+    }
+    return false;
+  }
+  return true;
+}

--- a/src/aktualizr_lite/helpers.cc
+++ b/src/aktualizr_lite/helpers.cc
@@ -110,3 +110,28 @@ bool target_has_tags(const Uptane::Target &t, const std::vector<std::string> &co
   }
   return true;
 }
+
+bool targets_eq(const Uptane::Target &t1, const Uptane::Target &t2, bool compareDockerApps) {
+  // target equality check looks at hashes
+  if (t1.MatchTarget(t2)) {
+    if (compareDockerApps) {
+      auto t1_apps = t1.custom_data()["docker_apps"];
+      auto t2_apps = t2.custom_data()["docker_apps"];
+      for (Json::ValueIterator i = t1_apps.begin(); i != t1_apps.end(); ++i) {
+        auto app = i.key().asString();
+        if (!t2_apps.isMember(app)) {
+          return false;  // an app has been removed
+        }
+        if ((*i)["filename"].asString() != t2_apps[app]["filename"].asString()) {
+          return false;  // tuf target filename changed
+        }
+        t2_apps.removeMember(app);
+      }
+      if (t2_apps.size() > 0) {
+        return false;  // an app has been added
+      }
+    }
+    return true;  // docker apps are the same, or there are none
+  }
+  return false;
+}

--- a/src/aktualizr_lite/helpers.cc
+++ b/src/aktualizr_lite/helpers.cc
@@ -204,3 +204,26 @@ bool targets_eq(const Uptane::Target &t1, const Uptane::Target &t2, bool compare
   }
   return false;
 }
+
+bool known_local_target(LiteClient &client, const Uptane::Target &t, std::vector<Uptane::Target> &installed_versions) {
+  bool known_target = false;
+  auto current = client.primary->getCurrent();
+  boost::optional<Uptane::Target> pending;
+  client.storage->loadPrimaryInstalledVersions(nullptr, &pending);
+
+  if (t.sha256Hash() != current.sha256Hash()) {
+    std::vector<Uptane::Target>::reverse_iterator it;
+    for (it = installed_versions.rbegin(); it != installed_versions.rend(); it++) {
+      if (it->sha256Hash() == t.sha256Hash()) {
+        // Make sure installed version is not what is currently pending
+        if ((pending != boost::none) && (it->sha256Hash() == pending->sha256Hash())) {
+          continue;
+        }
+        LOG_INFO << "Target sha256Hash " << t.sha256Hash() << " known locally (rollback?), skipping";
+        known_target = true;
+        break;
+      }
+    }
+  }
+  return known_target;
+}

--- a/src/aktualizr_lite/helpers.cc
+++ b/src/aktualizr_lite/helpers.cc
@@ -107,6 +107,12 @@ LiteClient::LiteClient(Config &config_in) : config(std::move(config_in)), primar
   headers.push_back(header);
   add_apps_header(headers, config.pacman);
 
+  if (!config.telemetry.report_network) {
+    // Provide the random primary ECU serial so our backend will have some
+    // idea of the number of unique devices using the system
+    headers.emplace_back("x-ats-primary: " + primary_serial.ToString());
+  }
+
   headers.emplace_back("x-ats-target: unknown");
   headers.emplace_back("x-ats-tags: " + boost::algorithm::join(config.pacman.tags, ","));
   http_client = std::make_shared<HttpClient>(&headers);

--- a/src/aktualizr_lite/helpers.cc
+++ b/src/aktualizr_lite/helpers.cc
@@ -4,6 +4,7 @@
 #include <boost/uuid/uuid_io.hpp>
 
 #include "package_manager/ostreemanager.h"
+#include "package_manager/packagemanagerfactory.h"
 
 #ifdef BUILD_DOCKERAPP
 static void add_apps_header(std::vector<std::string> &headers, PackageConfig &config) {
@@ -16,7 +17,10 @@ static void add_apps_header(std::vector<std::string> &headers, PackageConfig &co
   {}
 #endif
 
-static std::pair<bool, Uptane::Target> finalizeIfNeeded(INvStorage &storage, PackageConfig &config) {
+static std::pair<Uptane::Target, data::ResultCode::Numeric> finalizeIfNeeded(PackageManagerInterface &package_manager,
+                                                                             INvStorage &storage,
+                                                                             PackageConfig &config) {
+  data::ResultCode::Numeric result_code = data::ResultCode::Numeric::kUnknown;
   boost::optional<Uptane::Target> pending_version;
   storage.loadInstalledVersions("", nullptr, &pending_version);
 
@@ -32,8 +36,23 @@ static std::pair<bool, Uptane::Target> finalizeIfNeeded(INvStorage &storage, Pac
     if (current_hash == target.sha256Hash()) {
       LOG_INFO << "Marking target install complete for: " << target;
       storage.saveInstalledVersion("", target, InstalledVersionUpdateMode::kCurrent);
-      return std::make_pair(true, target);
+      result_code = data::ResultCode::Numeric::kOk;
+      if (package_manager.rebootDetected()) {
+        package_manager.rebootFlagClear();
+      }
+    } else {
+      if (package_manager.rebootDetected()) {
+        LOG_ERROR << "Expected to boot on " << target.sha256Hash() << " but found " << current_hash
+                  << ", system might have experienced a rollback";
+        storage.saveInstalledVersion("", target, InstalledVersionUpdateMode::kNone);
+        package_manager.rebootFlagClear();
+        result_code = data::ResultCode::Numeric::kInstallFailed;
+      } else {
+        // Update still pending as no reboot was detected
+        result_code = data::ResultCode::Numeric::kNeedCompletion;
+      }
     }
+    return std::make_pair(target, result_code);
   }
 
   std::vector<Uptane::Target> installed_versions;
@@ -46,10 +65,10 @@ static std::pair<bool, Uptane::Target> finalizeIfNeeded(INvStorage &storage, Pac
   std::vector<Uptane::Target>::reverse_iterator it;
   for (it = installed_versions.rbegin(); it != installed_versions.rend(); it++) {
     if (it->sha256Hash() == current_hash) {
-      return std::make_pair(false, *it);
+      return std::make_pair(*it, data::ResultCode::Numeric::kAlreadyProcessed);
     }
   }
-  return std::make_pair(false, Uptane::Target::Unknown());
+  return std::make_pair(Uptane::Target::Unknown(), result_code);
 }
 
 LiteClient::LiteClient(Config &config_in) : config(std::move(config_in)), primary_serial(Uptane::EcuSerial::Unknown()) {
@@ -88,21 +107,24 @@ LiteClient::LiteClient(Config &config_in) : config(std::move(config_in)), primar
   headers.push_back(header);
   add_apps_header(headers, config.pacman);
 
-  std::pair<bool, Uptane::Target> pair = finalizeIfNeeded(*storage, config.pacman);
-  headers.emplace_back("x-ats-target: " + pair.second.filename());
+  headers.emplace_back("x-ats-target: unknown");
   headers.emplace_back("x-ats-tags: " + boost::algorithm::join(config.pacman.tags, ","));
-
   http_client = std::make_shared<HttpClient>(&headers);
   report_queue = std_::make_unique<ReportQueue>(config, http_client);
+  package_manager = PackageManagerFactory::makePackageManager(config.pacman, config.bootloader, storage, http_client);
 
-  if (pair.first) {
-    notifyInstallFinished(pair.second, data::ResultCode::Numeric::kOk);
-  }
+  std::pair<Uptane::Target, data::ResultCode::Numeric> pair =
+      finalizeIfNeeded(*package_manager, *storage, config.pacman);
+  http_client->updateHeader("x-ats-target", pair.first.filename());
 
   KeyManager keys(storage, config.keymanagerConfig());
   keys.copyCertsToCurl(*http_client);
 
   primary = std::make_shared<SotaUptaneClient>(config, storage, http_client);
+
+  if (pair.second != data::ResultCode::Numeric::kAlreadyProcessed) {
+    notifyInstallFinished(pair.first, pair.second);
+  }
 }
 
 void LiteClient::notify(const Uptane::Target &t, std::unique_ptr<ReportEvent> event) {

--- a/src/aktualizr_lite/helpers.cc
+++ b/src/aktualizr_lite/helpers.cc
@@ -92,7 +92,7 @@ LiteClient::LiteClient(Config &config_in) : config(std::move(config_in)), primar
   headers.emplace_back("x-ats-target: " + pair.second.filename());
   headers.emplace_back("x-ats-tags: " + boost::algorithm::join(config.pacman.tags, ","));
 
-  auto http_client = std::make_shared<HttpClient>(&headers);
+  http_client = std::make_shared<HttpClient>(&headers);
   report_queue = std_::make_unique<ReportQueue>(config, http_client);
 
   if (pair.first) {

--- a/src/aktualizr_lite/helpers.h
+++ b/src/aktualizr_lite/helpers.h
@@ -21,8 +21,18 @@ struct LiteClient {
   Config config;
   std::shared_ptr<INvStorage> storage;
   std::shared_ptr<SotaUptaneClient> primary;
+  std::unique_ptr<ReportQueue> report_queue;
+  Uptane::EcuSerial primary_serial;
+
+  void notifyDownloadStarted(const Uptane::Target& t);
+  void notifyDownloadFinished(const Uptane::Target& t, bool success);
+  void notifyInstallStarted(const Uptane::Target& t);
+  void notifyInstallFinished(const Uptane::Target& t, data::ResultCode::Numeric rc);
+
+  void notify(const Uptane::Target& t, std::unique_ptr<ReportEvent> event);
 };
 
+void generate_correlation_id(Uptane::Target& t);
 bool target_has_tags(const Uptane::Target& t, const std::vector<std::string>& config_tags);
 bool targets_eq(const Uptane::Target& t1, const Uptane::Target& t2, bool compareDockerApps);
 

--- a/src/aktualizr_lite/helpers.h
+++ b/src/aktualizr_lite/helpers.h
@@ -37,5 +37,6 @@ struct LiteClient {
 void generate_correlation_id(Uptane::Target& t);
 bool target_has_tags(const Uptane::Target& t, const std::vector<std::string>& config_tags);
 bool targets_eq(const Uptane::Target& t1, const Uptane::Target& t2, bool compareDockerApps);
+bool known_local_target(LiteClient& client, const Uptane::Target& t, std::vector<Uptane::Target>& installed_versions);
 
 #endif  // AKTUALIZR_LITE_HELPERS

--- a/src/aktualizr_lite/helpers.h
+++ b/src/aktualizr_lite/helpers.h
@@ -21,6 +21,7 @@ struct LiteClient {
   Config config;
   std::shared_ptr<INvStorage> storage;
   std::shared_ptr<SotaUptaneClient> primary;
+  std::shared_ptr<PackageManagerInterface> package_manager;
   std::unique_ptr<ReportQueue> report_queue;
   std::shared_ptr<HttpClient> http_client;
   Uptane::EcuSerial primary_serial;

--- a/src/aktualizr_lite/helpers.h
+++ b/src/aktualizr_lite/helpers.h
@@ -22,6 +22,7 @@ struct LiteClient {
   std::shared_ptr<INvStorage> storage;
   std::shared_ptr<SotaUptaneClient> primary;
   std::unique_ptr<ReportQueue> report_queue;
+  std::shared_ptr<HttpClient> http_client;
   Uptane::EcuSerial primary_serial;
 
   void notifyDownloadStarted(const Uptane::Target& t);

--- a/src/aktualizr_lite/helpers.h
+++ b/src/aktualizr_lite/helpers.h
@@ -6,6 +6,7 @@
 #include <string.h>
 
 #include "primary/sotauptaneclient.h"
+#include "uptane/tuf.h"
 
 struct Version {
   std::string raw_ver;
@@ -21,5 +22,7 @@ struct LiteClient {
   std::shared_ptr<INvStorage> storage;
   std::shared_ptr<SotaUptaneClient> primary;
 };
+
+bool target_has_tags(const Uptane::Target& t, const std::vector<std::string>& config_tags);
 
 #endif  // AKTUALIZR_LITE_HELPERS

--- a/src/aktualizr_lite/helpers.h
+++ b/src/aktualizr_lite/helpers.h
@@ -24,5 +24,6 @@ struct LiteClient {
 };
 
 bool target_has_tags(const Uptane::Target& t, const std::vector<std::string>& config_tags);
+bool targets_eq(const Uptane::Target& t1, const Uptane::Target& t2, bool compareDockerApps);
 
 #endif  // AKTUALIZR_LITE_HELPERS

--- a/src/aktualizr_lite/helpers.h
+++ b/src/aktualizr_lite/helpers.h
@@ -32,8 +32,11 @@ struct LiteClient {
   void notifyInstallFinished(const Uptane::Target& t, data::ResultCode::Numeric rc);
 
   void notify(const Uptane::Target& t, std::unique_ptr<ReportEvent> event);
+  bool dockerAppsChanged();
+  void storeDockerParamsDigest();
 };
 
+bool should_compare_docker_apps(const Config& config);
 void generate_correlation_id(Uptane::Target& t);
 bool target_has_tags(const Uptane::Target& t, const std::vector<std::string>& config_tags);
 bool targets_eq(const Uptane::Target& t1, const Uptane::Target& t2, bool compareDockerApps);

--- a/src/aktualizr_lite/helpers_test.cc
+++ b/src/aktualizr_lite/helpers_test.cc
@@ -51,6 +51,37 @@ TEST(helpers, lite_client_finalize) {
   ASSERT_FALSE(target.MatchHash(LiteClient(config).primary->getCurrent().hashes()[0]));
 }
 
+TEST(helpers, target_has_tags) {
+  auto t = Uptane::Target::Unknown();
+
+  // No tags defined in target:
+  std::vector<std::string> config_tags;
+  ASSERT_TRUE(target_has_tags(t, config_tags));
+  config_tags.push_back("foo");
+  ASSERT_FALSE(target_has_tags(t, config_tags));
+
+  // Set target tags to: premerge, qa
+  auto custom = t.custom_data();
+  custom["tags"].append("premerge");
+  custom["tags"].append("qa");
+  t.updateCustom(custom);
+
+  config_tags.clear();
+  ASSERT_TRUE(target_has_tags(t, config_tags));
+
+  config_tags.push_back("qa");
+  config_tags.push_back("blah");
+  ASSERT_TRUE(target_has_tags(t, config_tags));
+
+  config_tags.clear();
+  config_tags.push_back("premerge");
+  ASSERT_TRUE(target_has_tags(t, config_tags));
+
+  config_tags.clear();
+  config_tags.push_back("foo");
+  ASSERT_FALSE(target_has_tags(t, config_tags));
+}
+
 #ifndef __NO_MAIN__
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);

--- a/src/aktualizr_lite/helpers_test.cc
+++ b/src/aktualizr_lite/helpers_test.cc
@@ -82,6 +82,47 @@ TEST(helpers, target_has_tags) {
   ASSERT_FALSE(target_has_tags(t, config_tags));
 }
 
+TEST(helpers, targets_eq) {
+  auto t1 = Uptane::Target::Unknown();
+  auto t2 = Uptane::Target::Unknown();
+
+  // t1 should equal t2 when there a no docker-apps
+  ASSERT_TRUE(targets_eq(t1, t2, false));
+  ASSERT_TRUE(targets_eq(t1, t2, true));
+
+  auto custom = t1.custom_data();
+  custom["docker_apps"]["app1"]["filename"] = "app1-v1";
+  t1.updateCustom(custom);
+  ASSERT_TRUE(targets_eq(t1, t2, false));  // still equal, ignoring docker-apps
+  ASSERT_FALSE(targets_eq(t1, t2, true));
+
+  custom = t2.custom_data();
+  custom["docker_apps"]["app1"]["filename"] = "app1-v1";
+  t2.updateCustom(custom);
+  ASSERT_TRUE(targets_eq(t1, t2, true));
+
+  custom["docker_apps"]["app1"]["filename"] = "app1-v2";
+  t2.updateCustom(custom);
+  ASSERT_FALSE(targets_eq(t1, t2, true));  // version has changed
+
+  // Get things the same again
+  custom["docker_apps"]["app1"]["filename"] = "app1-v1";
+  t2.updateCustom(custom);
+
+  custom["docker_apps"]["app2"]["filename"] = "app2-v2";
+  t2.updateCustom(custom);
+  ASSERT_FALSE(targets_eq(t1, t2, true));  // t2 has an app that t1 doesn't
+
+  custom = t1.custom_data();
+  custom["docker_apps"]["app2"]["filename"] = "app2-v1";
+  t1.updateCustom(custom);
+  ASSERT_FALSE(targets_eq(t1, t2, true));  // app2 versions differ
+
+  custom["docker_apps"]["app2"]["filename"] = "app2-v2";
+  t1.updateCustom(custom);
+  ASSERT_TRUE(targets_eq(t1, t2, true));
+}
+
 #ifndef __NO_MAIN__
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);

--- a/src/aktualizr_lite/main.cc
+++ b/src/aktualizr_lite/main.cc
@@ -137,42 +137,53 @@ static int get_lock(const char *lockfile) {
   return fd;
 }
 
-static int do_update(LiteClient &client, Uptane::Target &target, const char *lockfile) {
+static data::ResultCode::Numeric do_update(LiteClient &client, Uptane::Target &target, const char *lockfile) {
   generate_correlation_id(target);
   client.notifyDownloadStarted(target);
   if (!client.primary->downloadImage(target).first) {
     client.notifyDownloadFinished(target, false);
-    return 1;
+    return data::ResultCode::Numeric::kDownloadFailed;
   }
   client.notifyDownloadFinished(target, true);
 
   if (client.primary->VerifyTarget(target) != TargetStatus::kGood) {
     client.notifyInstallFinished(target, data::ResultCode::Numeric::kValidationFailed);
     LOG_ERROR << "Downloaded target is invalid";
+    return data::ResultCode::Numeric::kValidationFailed;
   }
 
   int lockfd = 0;
   if (lockfile != nullptr && (lockfd = get_lock(lockfile)) < 0) {
-    return 1;
+    return data::ResultCode::Numeric::kInternalError;
   }
+
+  Uptane::Target current = client.primary->getCurrent();
 
   client.notifyInstallStarted(target);
   auto iresult = client.primary->PackageInstall(target);
+  // Make sure the update wasn't just for docker-apps
+  if (iresult.result_code.num_code == data::ResultCode::Numeric::kNeedCompletion) {
+    for (const auto &it : current.hashes()) {
+      if (target.MatchHash(it)) {
+        iresult.result_code.num_code = data::ResultCode::Numeric::kOk;
+        break;
+      }
+    }
+  }
   client.notifyInstallFinished(target, iresult.result_code.num_code);
   if (iresult.result_code.num_code == data::ResultCode::Numeric::kNeedCompletion) {
     LOG_INFO << "Update complete. Please reboot the device to activate";
     client.storage->savePrimaryInstalledVersion(target, InstalledVersionUpdateMode::kPending);
   } else if (iresult.result_code.num_code == data::ResultCode::Numeric::kOk) {
+    LOG_INFO << "Update complete. No reboot needed";
     client.storage->savePrimaryInstalledVersion(target, InstalledVersionUpdateMode::kCurrent);
     close(lockfd);
   } else {
     LOG_ERROR << "Unable to install update: " << iresult.description;
     // let go of the lock since we couldn't update
     close(lockfd);
-    return 1;
   }
-  LOG_INFO << iresult.description;
-  return 0;
+  return iresult.result_code.num_code;
 }
 
 static int update_main(LiteClient &client, const bpo::variables_map &variables_map) {
@@ -189,7 +200,11 @@ static int update_main(LiteClient &client, const bpo::variables_map &variables_m
     return 0;
   }
   LOG_INFO << "Updating to: " << *target;
-  return do_update(client, *target, nullptr);
+  data::ResultCode::Numeric rc = do_update(client, *target, nullptr);
+  if (rc == data::ResultCode::Numeric::kNeedCompletion || rc == data::ResultCode::Numeric::kOk) {
+    return 0;
+  }
+  return 1;
 }
 
 static int daemon_main(LiteClient &client, const bpo::variables_map &variables_map) {
@@ -237,12 +252,16 @@ static int daemon_main(LiteClient &client, const bpo::variables_map &variables_m
     auto target = find_target(client.primary, hwid, client.config.pacman.tags, "latest");
     if (target != nullptr && !targets_eq(*target, current, compareDockerApps)) {
       LOG_INFO << "Updating base image to: " << *target;
-      if (do_update(client, *target, lockfile) == 0) {
-        if (target->MatchHash(current.hashes()[0])) {
-          LOG_INFO << "Update applied, hashes haven't changed";
-          client.storage->savePrimaryInstalledVersion(*target, InstalledVersionUpdateMode::kCurrent);
-          current = *target;
-        } else if (std::system(client.config.bootloader.reboot_command.c_str()) != 0) {
+
+      data::ResultCode::Numeric rc = do_update(client, *target, lockfile);
+      if (rc == data::ResultCode::Numeric::kOk) {
+        current = *target;
+        client.http_client->updateHeader("x-ats-target", current.filename());
+        // Start the loop over to call updateImagesMeta which will update this
+        // device's target name on the server.
+        continue;
+      } else if (rc == data::ResultCode::Numeric::kNeedCompletion) {
+        if (std::system(client.config.bootloader.reboot_command.c_str()) != 0) {
           LOG_ERROR << "Unable to reboot system";
           return 1;
         }

--- a/src/aktualizr_lite/main.cc
+++ b/src/aktualizr_lite/main.cc
@@ -227,6 +227,12 @@ static int daemon_main(LiteClient &client, const bpo::variables_map &variables_m
     }
 
     client.primary->reportNetworkInfo();
+    // reportNetworkInfo already checks `telemetry.report_network`. We need a
+    // way when not running in anonymous mode to decide if we should report
+    // hwinfo to the server. This flag is a good one to (ab)use.
+    if (client.config.telemetry.report_network) {
+      client.primary->reportHwInfo();
+    }
 
     auto target = find_target(client.primary, hwid, client.config.pacman.tags, "latest");
     if (target != nullptr && !targets_eq(*target, current, compareDockerApps)) {

--- a/src/aktualizr_lite/main.cc
+++ b/src/aktualizr_lite/main.cc
@@ -225,6 +225,9 @@ static int daemon_main(LiteClient &client, const bpo::variables_map &variables_m
       std::this_thread::sleep_for(std::chrono::seconds(10));
       continue;  // There's no point trying to look for an update
     }
+
+    client.primary->reportNetworkInfo();
+
     auto target = find_target(client.primary, hwid, client.config.pacman.tags, "latest");
     if (target != nullptr && !targets_eq(*target, current, compareDockerApps)) {
       LOG_INFO << "Updating base image to: " << *target;
@@ -345,6 +348,7 @@ int main(int argc, char *argv[]) {
 
     Config config(commandline_map);
     config.storage.uptane_metadata_path = BasedPath(config.storage.path / "metadata");
+    config.telemetry.report_network = !config.tls.server.empty();
     LOG_DEBUG << "Current directory: " << boost::filesystem::current_path().string();
 
     std::string cmd = commandline_map["command"].as<std::string>();

--- a/src/aktualizr_lite/test_lite.sh
+++ b/src/aktualizr_lite/test_lite.sh
@@ -70,16 +70,16 @@ repo_server = "http://localhost:$port/repo/repo"
 [provision]
 primary_ecu_hardware_id = "hwid-for-test"
 
-[pacman]
-type = "ostree"
-sysroot = "$OSTREE_SYSROOT"
-os = "dummy-os"
-
 [storage]
 type = "sqlite"
 path = "$sota_dir"
 sqldb_path = "sql.db"
 uptane_metadata_path = "$sota_dir/metadata"
+
+[pacman]
+type = "ostree"
+sysroot = "$OSTREE_SYSROOT"
+os = "dummy-os"
 EOF
 
 ## Check that we can do the info command
@@ -114,3 +114,8 @@ if [[ ! "$out" =~ "Active image is: zlast	sha256:$sha" ]] ; then
     echo $out
     exit 1
 fi
+
+## Make sure we obey tags
+echo 'tags = "promoted"' >> $sota_dir/sota.toml
+cd /tmp/
+OSTREE_HASH=$sha LD_PRELOAD=$mock_ostree $valgrind $aklite --loglevel 1 -c $sota_dir/sota.toml update | grep "Already up-to-date"

--- a/src/libaktualizr/bootloader/bootloader.cc
+++ b/src/libaktualizr/bootloader/bootloader.cc
@@ -41,6 +41,11 @@ void Bootloader::setBootOK() const {
         LOG_WARNING << "Failed resetting upgrade_available for u-boot";
       }
       break;
+    case RollbackMode::kFioVB:
+      if (Utils::shell("fiovb_setenv bootcount 0", &sink) != 0) {
+        LOG_WARNING << "Failed resetting bootcount";
+      }
+      break;
     default:
       throw NotImplementedException();
   }
@@ -67,6 +72,14 @@ void Bootloader::updateNotify() const {
         LOG_WARNING << "Failed setting upgrade_available for u-boot";
       }
       if (Utils::shell("fw_setenv rollback 0", &sink) != 0) {
+        LOG_WARNING << "Failed resetting rollback flag";
+      }
+      break;
+    case RollbackMode::kFioVB:
+      if (Utils::shell("fiovb_setenv bootcount 0", &sink) != 0) {
+        LOG_WARNING << "Failed resetting bootcount";
+      }
+      if (Utils::shell("fiovb_setenv rollback 0", &sink) != 0) {
         LOG_WARNING << "Failed resetting rollback flag";
       }
       break;

--- a/src/libaktualizr/bootloader/bootloader_config.cc
+++ b/src/libaktualizr/bootloader/bootloader_config.cc
@@ -10,6 +10,9 @@ std::ostream& operator<<(std::ostream& os, RollbackMode mode) {
     case RollbackMode::kUbootMasked:
       mode_s = "uboot_masked";
       break;
+    case RollbackMode::kFioVB:
+      mode_s = "fiovb";
+      break;
     default:
       mode_s = "none";
       break;
@@ -27,6 +30,8 @@ inline void CopyFromConfig(RollbackMode& dest, const std::string& option_name, c
       dest = RollbackMode::kUbootGeneric;
     } else if (mode == "uboot_masked") {
       dest = RollbackMode::kUbootMasked;
+    } else if (mode == "fiovb") {
+      dest = RollbackMode::kFioVB;
     } else {
       dest = RollbackMode::kBootloaderNone;
     }

--- a/src/libaktualizr/bootloader/bootloader_config.h
+++ b/src/libaktualizr/bootloader/bootloader_config.h
@@ -5,7 +5,7 @@
 #include <boost/property_tree/ini_parser.hpp>
 #include <ostream>
 
-enum class RollbackMode { kBootloaderNone = 0, kUbootGeneric, kUbootMasked };
+enum class RollbackMode { kBootloaderNone = 0, kUbootGeneric, kUbootMasked, kFioVB };
 std::ostream& operator<<(std::ostream& os, RollbackMode mode);
 
 struct BootloaderConfig {

--- a/src/libaktualizr/config/config.h
+++ b/src/libaktualizr/config/config.h
@@ -51,7 +51,7 @@ struct ProvisionConfig {
 };
 
 struct UptaneConfig {
-  uint64_t polling_sec{10u};
+  uint64_t polling_sec{300u};
   std::string director_server;
   std::string repo_server;
   CryptoSource key_source{CryptoSource::kFile};

--- a/src/libaktualizr/config/config.h
+++ b/src/libaktualizr/config/config.h
@@ -100,7 +100,8 @@ class Config : public BaseConfig {
   void updateFromPropertyTree(const boost::property_tree::ptree& pt) override;
   void updateFromCommandLine(const boost::program_options::variables_map& cmd);
 
-  std::vector<boost::filesystem::path> config_dirs_ = {"/usr/lib/sota/conf.d", "/etc/sota/conf.d/"};
+  std::vector<boost::filesystem::path> config_dirs_ = {"/usr/lib/sota/conf.d", "/var/sota/sota.toml",
+                                                       "/etc/sota/conf.d/"};
   bool loglevel_from_cmdline{false};
 };
 

--- a/src/libaktualizr/package_manager/dockerappmanager.cc
+++ b/src/libaktualizr/package_manager/dockerappmanager.cc
@@ -145,6 +145,11 @@ data::InstallationResult DockerAppManager::install(const Uptane::Target &target)
   data::InstallationResult res;
   Uptane::Target current = OstreeManager::getCurrent();
   if (current.sha256Hash() != target.sha256Hash()) {
+    // notify the bootloader before installation happens as it is not atomic
+    // and a false notification doesn't hurt with rollback support in place
+    if (bootloader_ != nullptr) {
+      bootloader_->updateNotify();
+    }
     res = OstreeManager::install(target);
     if (res.result_code.num_code == data::ResultCode::Numeric::kInstallFailed) {
       LOG_ERROR << "Failed to install OSTree target, skipping Docker Apps";

--- a/src/libaktualizr/package_manager/dockerappmanager.cc
+++ b/src/libaktualizr/package_manager/dockerappmanager.cc
@@ -152,7 +152,15 @@ data::InstallationResult DockerAppManager::install(const Uptane::Target &target)
     return dapp.render(ss.str(), true) && dapp.start();
   };
   if (!iterate_apps(target, cb)) {
-    return data::InstallationResult(data::ResultCode::Numeric::kInstallFailed, "Could not render docker app");
+    res = data::InstallationResult(data::ResultCode::Numeric::kInstallFailed, "Could not render docker app");
+  }
+  if (config.docker_prune) {
+    LOG_INFO << "Pruning unused docker images";
+    // Utils::shell which isn't interactive, we'll use std::system so that
+    // stdout/stderr is streamed while docker sets things up.
+    if (std::system("docker image prune -a -f") != 0) {
+      LOG_WARNING << "Unable to prune unused docker images";
+    }
   }
   return res;
 }

--- a/src/libaktualizr/package_manager/dockerappmanager_test.cc
+++ b/src/libaktualizr/package_manager/dockerappmanager_test.cc
@@ -62,6 +62,7 @@ TEST(DockerAppManager, DockerApp_Fetch) {
   config.pacman.docker_apps_root = temp_dir / "docker_apps";
   config.pacman.docker_apps.push_back("app1");
   config.pacman.docker_app_bin = config.pacman.docker_compose_bin = "src/libaktualizr/package_manager/docker_fake.sh";
+  config.pacman.docker_prune = false;
   config.pacman.ostree_server = treehub_server;
   config.uptane.repo_server = repo_server + "/repo/repo";
   TemporaryDirectory dir;

--- a/src/libaktualizr/package_manager/packagemanagerconfig.cc
+++ b/src/libaktualizr/package_manager/packagemanagerconfig.cc
@@ -33,11 +33,16 @@ void PackageConfig::updateFromPropertyTree(const boost::property_tree::ptree& pt
   CopyFromConfig(ostree_server, "ostree_server", pt);
   CopyFromConfig(packages_file, "packages_file", pt);
   CopyFromConfig(fake_need_reboot, "fake_need_reboot", pt);
+  std::string val;
+  CopyFromConfig(val, "tags", pt);
+  if (val.length() > 0) {
+    boost::split(tags, val, boost::is_any_of(", "), boost::token_compress_on);
+    val.clear();  // this is re-used by docker_apps
+  }
 #ifdef BUILD_DOCKERAPP
   CopyFromConfig(docker_apps_root, "docker_apps_root", pt);
   CopyFromConfig(docker_compose_bin, "docker_compose_bin", pt);
   CopyFromConfig(docker_prune, "docker_prune", pt);
-  std::string val;
   CopyFromConfig(val, "docker_apps", pt);
   if (val.length() > 0) {
     // token_compress_on allows lists like: "foo,bar", "foo, bar", or "foo bar"
@@ -55,6 +60,7 @@ void PackageConfig::writeToStream(std::ostream& out_stream) const {
   writeOption(out_stream, ostree_server, "ostree_server");
   writeOption(out_stream, packages_file, "packages_file");
   writeOption(out_stream, fake_need_reboot, "fake_need_reboot");
+  writeOption(out_stream, boost::algorithm::join(tags, ","), "tags");
 #ifdef BUILD_DOCKERAPP
   writeOption(out_stream, boost::algorithm::join(docker_apps, ","), "docker_apps");
   writeOption(out_stream, docker_apps_root, "docker_apps_root");

--- a/src/libaktualizr/package_manager/packagemanagerconfig.cc
+++ b/src/libaktualizr/package_manager/packagemanagerconfig.cc
@@ -36,6 +36,7 @@ void PackageConfig::updateFromPropertyTree(const boost::property_tree::ptree& pt
 #ifdef BUILD_DOCKERAPP
   CopyFromConfig(docker_apps_root, "docker_apps_root", pt);
   CopyFromConfig(docker_compose_bin, "docker_compose_bin", pt);
+  CopyFromConfig(docker_prune, "docker_prune", pt);
   std::string val;
   CopyFromConfig(val, "docker_apps", pt);
   if (val.length() > 0) {
@@ -60,5 +61,6 @@ void PackageConfig::writeToStream(std::ostream& out_stream) const {
   writeOption(out_stream, docker_app_params, "docker_app_params");
   writeOption(out_stream, docker_app_bin, "docker_app_bin");
   writeOption(out_stream, docker_compose_bin, "docker_compose_bin");
+  writeOption(out_stream, docker_prune, "docker_prune");
 #endif
 }

--- a/src/libaktualizr/package_manager/packagemanagerconfig.h
+++ b/src/libaktualizr/package_manager/packagemanagerconfig.h
@@ -27,6 +27,7 @@ struct PackageConfig {
   boost::filesystem::path docker_app_params;
   boost::filesystem::path docker_app_bin{"/usr/bin/docker-app"};
   boost::filesystem::path docker_compose_bin{"/usr/bin/docker-compose"};
+  bool docker_prune{true};
 #endif
 
   // Options for simulation (to be used with kNone)

--- a/src/libaktualizr/package_manager/packagemanagerconfig.h
+++ b/src/libaktualizr/package_manager/packagemanagerconfig.h
@@ -20,6 +20,7 @@ struct PackageConfig {
   boost::filesystem::path sysroot;
   std::string ostree_server;
   boost::filesystem::path packages_file{"/usr/package.manifest"};
+  std::vector<std::string> tags;
 
 #ifdef BUILD_DOCKERAPP
   std::vector<std::string> docker_apps;

--- a/src/libaktualizr/primary/sotauptaneclient.h
+++ b/src/libaktualizr/primary/sotauptaneclient.h
@@ -75,6 +75,7 @@ class SotaUptaneClient {
   bool checkImagesMetaOffline();
   data::InstallationResult PackageInstall(const Uptane::Target &target);
   TargetStatus VerifyTarget(const Uptane::Target &target) { return package_manager_->verifyTarget(target); }
+  void reportNetworkInfo();
 
  protected:
   void addSecondary(const std::shared_ptr<Uptane::SecondaryInterface> &sec);
@@ -123,7 +124,6 @@ class SotaUptaneClient {
   void finalizeAfterReboot();
   void reportHwInfo();
   void reportInstalledPackages();
-  void reportNetworkInfo();
   void reportAktualizrConfiguration();
   void verifySecondaries();
   void sendMetadataToEcus(const std::vector<Uptane::Target> &targets);

--- a/src/libaktualizr/primary/sotauptaneclient.h
+++ b/src/libaktualizr/primary/sotauptaneclient.h
@@ -76,6 +76,7 @@ class SotaUptaneClient {
   data::InstallationResult PackageInstall(const Uptane::Target &target);
   TargetStatus VerifyTarget(const Uptane::Target &target) { return package_manager_->verifyTarget(target); }
   void reportNetworkInfo();
+  void reportHwInfo();
 
  protected:
   void addSecondary(const std::shared_ptr<Uptane::SecondaryInterface> &sec);
@@ -122,7 +123,6 @@ class SotaUptaneClient {
                                                 const Uptane::EcuSerial &ecu_id);
   data::InstallationResult PackageInstallSetResult(const Uptane::Target &target);
   void finalizeAfterReboot();
-  void reportHwInfo();
   void reportInstalledPackages();
   void reportAktualizrConfiguration();
   void verifySecondaries();

--- a/src/libaktualizr/utilities/config_utils.h
+++ b/src/libaktualizr/utilities/config_utils.h
@@ -164,7 +164,8 @@ class BaseConfig {
     }
   }
 
-  std::vector<boost::filesystem::path> config_dirs_ = {"/usr/lib/sota/conf.d", "/etc/sota/conf.d/"};
+  std::vector<boost::filesystem::path> config_dirs_ = {"/usr/lib/sota/conf.d", "/var/sota/sota.toml",
+                                                       "/etc/sota/conf.d/"};
 };
 
 #endif  // CONFIG_UTILS_H_

--- a/src/libaktualizr/utilities/sig_handler.cc
+++ b/src/libaktualizr/utilities/sig_handler.cc
@@ -1,7 +1,7 @@
 #include "sig_handler.h"
 #include "logging/logging.h"
 
-std::atomic<bool> SigHandler::signal_marker_;
+std::atomic_uint SigHandler::signal_marker_;
 std::mutex SigHandler::exit_m_;
 std::condition_variable SigHandler::exit_cv_;
 bool SigHandler::exit_flag_;
@@ -31,7 +31,7 @@ void SigHandler::start(const std::function<void()>& on_signal) {
   polling_thread_ = boost::thread([on_signal]() {
     std::unique_lock<std::mutex> l(exit_m_);
     while (true) {
-      bool got_signal = signal_marker_.exchange(false);
+      auto got_signal = signal_marker_.exchange(0);
 
       if (got_signal) {
         on_signal();
@@ -49,7 +49,7 @@ void SigHandler::signal(int sig) { ::signal(sig, signal_handler); }
 
 void SigHandler::signal_handler(int sig) {
   (void)sig;
-  bool v = false;
+  unsigned int v = 0;
   // put true if currently set to false
-  SigHandler::signal_marker_.compare_exchange_strong(v, true);
+  SigHandler::signal_marker_.compare_exchange_strong(v, 1);
 }

--- a/src/libaktualizr/utilities/sig_handler.h
+++ b/src/libaktualizr/utilities/sig_handler.h
@@ -31,7 +31,7 @@ class SigHandler {
   static void signal_handler(int sig);
 
   boost::thread polling_thread_;
-  static std::atomic<bool> signal_marker_;
+  static std::atomic_uint signal_marker_;
 
   static std::mutex exit_m_;
   static std::condition_variable exit_cv_;


### PR DESCRIPTION
This applies our patches onto the 2019.11 aktualizr base. Notable changes include:

 * Aktualizr can now send sota.toml configuration at start-up
 * Logging fixes were merged upstream
 * docker-app paramters are handled in a future compatible way