### PR TITLE
2020.1 rebase

### DIFF
--- a/src/aktualizr_lite/helpers.cc
+++ b/src/aktualizr_lite/helpers.cc
@@ -4,6 +4,7 @@
 #include <boost/uuid/uuid_io.hpp>
 
 #include "package_manager/ostreemanager.h"
+#include "package_manager/packagemanagerfactory.h"
 
 #ifdef BUILD_DOCKERAPP
 static void add_apps_header(std::vector<std::string> &headers, PackageConfig &config) {
@@ -16,7 +17,10 @@ static void add_apps_header(std::vector<std::string> &headers, PackageConfig &co
   {}
 #endif
 
-static std::pair<bool, Uptane::Target> finalizeIfNeeded(INvStorage &storage, PackageConfig &config) {
+static std::pair<Uptane::Target, data::ResultCode::Numeric> finalizeIfNeeded(PackageManagerInterface &package_manager,
+                                                                             INvStorage &storage,
+                                                                             PackageConfig &config) {
+  data::ResultCode::Numeric result_code = data::ResultCode::Numeric::kUnknown;
   boost::optional<Uptane::Target> pending_version;
   storage.loadInstalledVersions("", nullptr, &pending_version);
 
@@ -32,8 +36,23 @@ static std::pair<bool, Uptane::Target> finalizeIfNeeded(INvStorage &storage, Pac
     if (current_hash == target.sha256Hash()) {
       LOG_INFO << "Marking target install complete for: " << target;
       storage.saveInstalledVersion("", target, InstalledVersionUpdateMode::kCurrent);
-      return std::make_pair(true, target);
+      result_code = data::ResultCode::Numeric::kOk;
+      if (package_manager.rebootDetected()) {
+        package_manager.rebootFlagClear();
+      }
+    } else {
+      if (package_manager.rebootDetected()) {
+        LOG_ERROR << "Expected to boot on " << target.sha256Hash() << " but found " << current_hash
+                  << ", system might have experienced a rollback";
+        storage.saveInstalledVersion("", target, InstalledVersionUpdateMode::kNone);
+        package_manager.rebootFlagClear();
+        result_code = data::ResultCode::Numeric::kInstallFailed;
+      } else {
+        // Update still pending as no reboot was detected
+        result_code = data::ResultCode::Numeric::kNeedCompletion;
+      }
     }
+    return std::make_pair(target, result_code);
   }
 
   std::vector<Uptane::Target> installed_versions;
@@ -46,10 +65,10 @@ static std::pair<bool, Uptane::Target> finalizeIfNeeded(INvStorage &storage, Pac
   std::vector<Uptane::Target>::reverse_iterator it;
   for (it = installed_versions.rbegin(); it != installed_versions.rend(); it++) {
     if (it->sha256Hash() == current_hash) {
-      return std::make_pair(false, *it);
+      return std::make_pair(*it, data::ResultCode::Numeric::kAlreadyProcessed);
     }
   }
-  return std::make_pair(false, Uptane::Target::Unknown());
+  return std::make_pair(Uptane::Target::Unknown(), result_code);
 }
 
 LiteClient::LiteClient(Config &config_in)
@@ -87,8 +106,7 @@ LiteClient::LiteClient(Config &config_in)
   headers.push_back(header);
   add_apps_header(headers, config.pacman);
 
-  std::pair<bool, Uptane::Target> pair = finalizeIfNeeded(*storage, config.pacman);
-  headers.emplace_back("x-ats-target: " + pair.second.filename());
+  headers.emplace_back("x-ats-target: unknown");
 
   if (!config.telemetry.report_network) {
     // Provide the random primary ECU serial so our backend will have some
@@ -100,16 +118,21 @@ LiteClient::LiteClient(Config &config_in)
 
   http_client = std::make_shared<HttpClient>(&headers);
   report_queue = std_::make_unique<ReportQueue>(config, http_client);
+  package_manager = PackageManagerFactory::makePackageManager(config.pacman, config.bootloader, storage, http_client);
 
-  if (pair.first) {
-    notifyInstallFinished(pair.second, data::ResultCode::Numeric::kOk);
-  }
+  std::pair<Uptane::Target, data::ResultCode::Numeric> pair =
+      finalizeIfNeeded(*package_manager, *storage, config.pacman);
+  http_client->updateHeader("x-ats-target", pair.first.filename());
 
   KeyManager keys(storage, config.keymanagerConfig());
   keys.copyCertsToCurl(*http_client);
 
   primary = std::make_shared<SotaUptaneClient>(config, storage, http_client);
   primary->initializePrimaryEcu();
+
+  if (pair.second != data::ResultCode::Numeric::kAlreadyProcessed) {
+    notifyInstallFinished(pair.first, pair.second);
+  }
 }
 
 void LiteClient::notify(const Uptane::Target &t, std::unique_ptr<ReportEvent> event) {

--- a/src/aktualizr_lite/helpers.cc
+++ b/src/aktualizr_lite/helpers.cc
@@ -98,7 +98,7 @@ LiteClient::LiteClient(Config &config_in)
 
   headers.emplace_back("x-ats-tags: " + boost::algorithm::join(config.pacman.tags, ","));
 
-  auto http_client = std::make_shared<HttpClient>(&headers);
+  http_client = std::make_shared<HttpClient>(&headers);
   report_queue = std_::make_unique<ReportQueue>(config, http_client);
 
   if (pair.first) {

--- a/src/aktualizr_lite/helpers.cc
+++ b/src/aktualizr_lite/helpers.cc
@@ -16,7 +16,7 @@ static void add_apps_header(std::vector<std::string> &headers, PackageConfig &co
   {}
 #endif
 
-static Uptane::Target finalizeIfNeeded(INvStorage &storage, PackageConfig &config) {
+static std::pair<bool, Uptane::Target> finalizeIfNeeded(INvStorage &storage, PackageConfig &config) {
   boost::optional<Uptane::Target> pending_version;
   storage.loadInstalledVersions("", nullptr, &pending_version);
 
@@ -32,7 +32,7 @@ static Uptane::Target finalizeIfNeeded(INvStorage &storage, PackageConfig &confi
     if (current_hash == target.sha256Hash()) {
       LOG_INFO << "Marking target install complete for: " << target;
       storage.saveInstalledVersion("", target, InstalledVersionUpdateMode::kCurrent);
-      return target;
+      return std::make_pair(true, target);
     }
   }
 
@@ -46,10 +46,10 @@ static Uptane::Target finalizeIfNeeded(INvStorage &storage, PackageConfig &confi
   std::vector<Uptane::Target>::reverse_iterator it;
   for (it = installed_versions.rbegin(); it != installed_versions.rend(); it++) {
     if (it->sha256Hash() == current_hash) {
-      return *it;
+      return std::make_pair(false, *it);
     }
   }
-  return Uptane::Target::Unknown();
+  return std::make_pair(false, Uptane::Target::Unknown());
 }
 
 LiteClient::LiteClient(Config &config_in)
@@ -87,8 +87,8 @@ LiteClient::LiteClient(Config &config_in)
   headers.push_back(header);
   add_apps_header(headers, config.pacman);
 
-  Uptane::Target tgt = finalizeIfNeeded(*storage, config.pacman);
-  headers.emplace_back("x-ats-target: " + tgt.filename());
+  std::pair<bool, Uptane::Target> pair = finalizeIfNeeded(*storage, config.pacman);
+  headers.emplace_back("x-ats-target: " + pair.second.filename());
 
   if (!config.telemetry.report_network) {
     // Provide the random primary ECU serial so our backend will have some
@@ -99,12 +99,56 @@ LiteClient::LiteClient(Config &config_in)
   headers.emplace_back("x-ats-tags: " + boost::algorithm::join(config.pacman.tags, ","));
 
   auto http_client = std::make_shared<HttpClient>(&headers);
+  report_queue = std_::make_unique<ReportQueue>(config, http_client);
+
+  if (pair.first) {
+    notifyInstallFinished(pair.second, data::ResultCode::Numeric::kOk);
+  }
 
   KeyManager keys(storage, config.keymanagerConfig());
   keys.copyCertsToCurl(*http_client);
 
   primary = std::make_shared<SotaUptaneClient>(config, storage, http_client);
   primary->initializePrimaryEcu();
+}
+
+void LiteClient::notify(const Uptane::Target &t, std::unique_ptr<ReportEvent> event) {
+  if (!config.tls.server.empty()) {
+    event->custom["targetName"] = t.filename();
+    event->custom["version"] = t.custom_version();
+    report_queue->enqueue(std::move(event));
+  }
+}
+
+void LiteClient::notifyDownloadStarted(const Uptane::Target &t) {
+  notify(t, std_::make_unique<EcuDownloadStartedReport>(primary_ecu.first, t.correlation_id()));
+}
+
+void LiteClient::notifyDownloadFinished(const Uptane::Target &t, bool success) {
+  notify(t, std_::make_unique<EcuDownloadCompletedReport>(primary_ecu.first, t.correlation_id(), success));
+}
+
+void LiteClient::notifyInstallStarted(const Uptane::Target &t) {
+  notify(t, std_::make_unique<EcuInstallationStartedReport>(primary_ecu.first, t.correlation_id()));
+}
+
+void LiteClient::notifyInstallFinished(const Uptane::Target &t, data::ResultCode::Numeric rc) {
+  if (rc == data::ResultCode::Numeric::kNeedCompletion) {
+    notify(t, std_::make_unique<EcuInstallationAppliedReport>(primary_ecu.first, t.correlation_id()));
+  } else if (rc == data::ResultCode::Numeric::kOk) {
+    notify(t, std_::make_unique<EcuInstallationCompletedReport>(primary_ecu.first, t.correlation_id(), true));
+  } else {
+    notify(t, std_::make_unique<EcuInstallationCompletedReport>(primary_ecu.first, t.correlation_id(), false));
+  }
+}
+
+void generate_correlation_id(Uptane::Target &t) {
+  std::string id = t.custom_version();
+  if (id.empty()) {
+    id = t.filename();
+  }
+  boost::uuids::uuid tmp = boost::uuids::random_generator()();
+  t.setCorrelationId(id + "-" + boost::uuids::to_string(tmp));
 }
 
 bool target_has_tags(const Uptane::Target &t, const std::vector<std::string> &config_tags) {

--- a/src/aktualizr_lite/helpers.cc
+++ b/src/aktualizr_lite/helpers.cc
@@ -5,24 +5,51 @@
 
 #include "package_manager/ostreemanager.h"
 
-static void finalizeIfNeeded(INvStorage &storage, PackageConfig &config) {
+#ifdef BUILD_DOCKERAPP
+static void add_apps_header(std::vector<std::string> &headers, PackageConfig &config) {
+  if (config.type == PackageManager::kOstreeDockerApp) {
+    headers.emplace_back("x-ats-dockerapps: " + boost::algorithm::join(config.docker_apps, ","));
+  }
+}
+#else
+#define add_apps_header(headers, config) \
+  {}
+#endif
+
+static Uptane::Target finalizeIfNeeded(INvStorage &storage, PackageConfig &config) {
   boost::optional<Uptane::Target> pending_version;
   storage.loadInstalledVersions("", nullptr, &pending_version);
 
-  if (!!pending_version) {
-    GObjectUniquePtr<OstreeSysroot> sysroot_smart = OstreeManager::LoadSysroot(config.sysroot);
-    OstreeDeployment *booted_deployment = ostree_sysroot_get_booted_deployment(sysroot_smart.get());
-    if (booted_deployment == nullptr) {
-      throw std::runtime_error("Could not get booted deployment in " + config.sysroot.string());
-    }
-    std::string current_hash = ostree_deployment_get_csum(booted_deployment);
+  GObjectUniquePtr<OstreeSysroot> sysroot_smart = OstreeManager::LoadSysroot(config.sysroot);
+  OstreeDeployment *booted_deployment = ostree_sysroot_get_booted_deployment(sysroot_smart.get());
+  std::string current_hash = ostree_deployment_get_csum(booted_deployment);
+  if (booted_deployment == nullptr) {
+    throw std::runtime_error("Could not get booted deployment in " + config.sysroot.string());
+  }
 
+  if (!!pending_version) {
     const Uptane::Target &target = *pending_version;
     if (current_hash == target.sha256Hash()) {
       LOG_INFO << "Marking target install complete for: " << target;
       storage.saveInstalledVersion("", target, InstalledVersionUpdateMode::kCurrent);
+      return target;
     }
   }
+
+  std::vector<Uptane::Target> installed_versions;
+  storage.loadPrimaryInstallationLog(&installed_versions, false);
+
+  // Version should be in installed versions. Its possible that multiple
+  // targets could have the same sha256Hash. In this case the safest assumption
+  // is that the most recent (the reverse of the vector) target is what we
+  // should return.
+  std::vector<Uptane::Target>::reverse_iterator it;
+  for (it = installed_versions.rbegin(); it != installed_versions.rend(); it++) {
+    if (it->sha256Hash() == current_hash) {
+      return *it;
+    }
+  }
+  return Uptane::Target::Unknown();
 }
 
 LiteClient::LiteClient(Config &config_in)
@@ -48,14 +75,36 @@ LiteClient::LiteClient(Config &config_in)
   }
   primary_ecu = ecu_serials[0];
 
-  auto http_client = std::make_shared<HttpClient>();
+  std::vector<std::string> headers;
+  GObjectUniquePtr<OstreeSysroot> sysroot_smart = OstreeManager::LoadSysroot(config.pacman.sysroot);
+  OstreeDeployment *deployment = ostree_sysroot_get_booted_deployment(sysroot_smart.get());
+  std::string header("x-ats-ostreehash: ");
+  if (deployment != nullptr) {
+    header += ostree_deployment_get_csum(deployment);
+  } else {
+    header += "?";
+  }
+  headers.push_back(header);
+  add_apps_header(headers, config.pacman);
+
+  Uptane::Target tgt = finalizeIfNeeded(*storage, config.pacman);
+  headers.emplace_back("x-ats-target: " + tgt.filename());
+
+  if (!config.telemetry.report_network) {
+    // Provide the random primary ECU serial so our backend will have some
+    // idea of the number of unique devices using the system
+    headers.emplace_back("x-ats-primary: " + primary_ecu.first.ToString());
+  }
+
+  headers.emplace_back("x-ats-tags: " + boost::algorithm::join(config.pacman.tags, ","));
+
+  auto http_client = std::make_shared<HttpClient>(&headers);
 
   KeyManager keys(storage, config.keymanagerConfig());
   keys.copyCertsToCurl(*http_client);
 
   primary = std::make_shared<SotaUptaneClient>(config, storage, http_client);
   primary->initializePrimaryEcu();
-  finalizeIfNeeded(*storage, config.pacman);
 }
 
 bool target_has_tags(const Uptane::Target &t, const std::vector<std::string> &config_tags) {

--- a/src/aktualizr_lite/helpers.cc
+++ b/src/aktualizr_lite/helpers.cc
@@ -256,6 +256,7 @@ static std::unique_ptr<Lock> create_lock(boost::filesystem::path lockfile) {
   return std_::make_unique<Lock>(fd);
 }
 
+std::unique_ptr<Lock> LiteClient::getDownloadLock() { return create_lock(download_lockfile); }
 std::unique_ptr<Lock> LiteClient::getUpdateLock() { return create_lock(update_lockfile); }
 
 void generate_correlation_id(Uptane::Target &t) {

--- a/src/aktualizr_lite/helpers.cc
+++ b/src/aktualizr_lite/helpers.cc
@@ -120,3 +120,28 @@ bool target_has_tags(const Uptane::Target &t, const std::vector<std::string> &co
   }
   return true;
 }
+
+bool targets_eq(const Uptane::Target &t1, const Uptane::Target &t2, bool compareDockerApps) {
+  // target equality check looks at hashes
+  if (t1.MatchTarget(t2)) {
+    if (compareDockerApps) {
+      auto t1_apps = t1.custom_data()["docker_apps"];
+      auto t2_apps = t2.custom_data()["docker_apps"];
+      for (Json::ValueIterator i = t1_apps.begin(); i != t1_apps.end(); ++i) {
+        auto app = i.key().asString();
+        if (!t2_apps.isMember(app)) {
+          return false;  // an app has been removed
+        }
+        if ((*i)["filename"].asString() != t2_apps[app]["filename"].asString()) {
+          return false;  // tuf target filename changed
+        }
+        t2_apps.removeMember(app);
+      }
+      if (t2_apps.size() > 0) {
+        return false;  // an app has been added
+      }
+    }
+    return true;  // docker apps are the same, or there are none
+  }
+  return false;
+}

--- a/src/aktualizr_lite/helpers.cc
+++ b/src/aktualizr_lite/helpers.cc
@@ -212,3 +212,26 @@ bool targets_eq(const Uptane::Target &t1, const Uptane::Target &t2, bool compare
   }
   return false;
 }
+
+bool known_local_target(LiteClient &client, const Uptane::Target &t, std::vector<Uptane::Target> &installed_versions) {
+  bool known_target = false;
+  auto current = client.primary->getCurrent();
+  boost::optional<Uptane::Target> pending;
+  client.storage->loadPrimaryInstalledVersions(nullptr, &pending);
+
+  if (t.sha256Hash() != current.sha256Hash()) {
+    std::vector<Uptane::Target>::reverse_iterator it;
+    for (it = installed_versions.rbegin(); it != installed_versions.rend(); it++) {
+      if (it->sha256Hash() == t.sha256Hash()) {
+        // Make sure installed version is not what is currently pending
+        if ((pending != boost::none) && (it->sha256Hash() == pending->sha256Hash())) {
+          continue;
+        }
+        LOG_INFO << "Target sha256Hash " << t.sha256Hash() << " known locally (rollback?), skipping";
+        known_target = true;
+        break;
+      }
+    }
+  }
+  return known_target;
+}

--- a/src/aktualizr_lite/helpers.cc
+++ b/src/aktualizr_lite/helpers.cc
@@ -1,8 +1,10 @@
-#include "helpers.h"
+#include <sys/file.h>
+#include <unistd.h>
 
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
 
+#include "helpers.h"
 #include "package_manager/ostreemanager.h"
 #include "package_manager/packagemanagerfactory.h"
 
@@ -233,6 +235,28 @@ void LiteClient::notifyInstallFinished(const Uptane::Target &t, data::ResultCode
     notify(t, std_::make_unique<EcuInstallationCompletedReport>(primary_ecu.first, t.correlation_id(), false));
   }
 }
+
+static std::unique_ptr<Lock> create_lock(boost::filesystem::path lockfile) {
+  if (lockfile.empty()) {
+    // Just return a dummy one that will safely "close"
+    return std_::make_unique<Lock>(-1);
+  }
+
+  int fd = open(lockfile.c_str(), O_RDWR | O_CREAT | O_APPEND, 0666);
+  if (fd < 0) {
+    LOG_ERROR << "Unable to open lock file " << lockfile;
+    return nullptr;
+  }
+  LOG_INFO << "Acquiring lock";
+  if (flock(fd, LOCK_EX) < 0) {
+    LOG_ERROR << "Unable to acquire lock on " << lockfile;
+    close(fd);
+    return nullptr;
+  }
+  return std_::make_unique<Lock>(fd);
+}
+
+std::unique_ptr<Lock> LiteClient::getUpdateLock() { return create_lock(update_lockfile); }
 
 void generate_correlation_id(Uptane::Target &t) {
   std::string id = t.custom_version();

--- a/src/aktualizr_lite/helpers.cc
+++ b/src/aktualizr_lite/helpers.cc
@@ -57,3 +57,17 @@ LiteClient::LiteClient(Config &config_in)
   primary->initializePrimaryEcu();
   finalizeIfNeeded(*storage, config.pacman);
 }
+
+bool target_has_tags(const Uptane::Target &t, const std::vector<std::string> &config_tags) {
+  if (!config_tags.empty()) {
+    auto tags = t.custom_data()["tags"];
+    for (Json::ValueIterator i = tags.begin(); i != tags.end(); ++i) {
+      auto tag = (*i).asString();
+      if (std::find(config_tags.begin(), config_tags.end(), tag) != config_tags.end()) {
+        return true;
+      }
+    }
+    return false;
+  }
+  return true;
+}

--- a/src/aktualizr_lite/helpers.h
+++ b/src/aktualizr_lite/helpers.h
@@ -37,5 +37,6 @@ struct LiteClient {
 void generate_correlation_id(Uptane::Target& t);
 bool target_has_tags(const Uptane::Target& t, const std::vector<std::string>& config_tags);
 bool targets_eq(const Uptane::Target& t1, const Uptane::Target& t2, bool compareDockerApps);
+bool known_local_target(LiteClient& client, const Uptane::Target& t, std::vector<Uptane::Target>& installed_versions);
 
 #endif  // AKTUALIZR_LITE_HELPERS

--- a/src/aktualizr_lite/helpers.h
+++ b/src/aktualizr_lite/helpers.h
@@ -32,8 +32,11 @@ struct LiteClient {
   void notifyInstallFinished(const Uptane::Target& t, data::ResultCode::Numeric rc);
 
   void notify(const Uptane::Target& t, std::unique_ptr<ReportEvent> event);
+  bool dockerAppsChanged();
+  void storeDockerParamsDigest();
 };
 
+bool should_compare_docker_apps(const Config& config);
 void generate_correlation_id(Uptane::Target& t);
 bool target_has_tags(const Uptane::Target& t, const std::vector<std::string>& config_tags);
 bool targets_eq(const Uptane::Target& t1, const Uptane::Target& t2, bool compareDockerApps);

--- a/src/aktualizr_lite/helpers.h
+++ b/src/aktualizr_lite/helpers.h
@@ -20,6 +20,7 @@ struct LiteClient {
   Config config;
   std::shared_ptr<INvStorage> storage;
   std::shared_ptr<SotaUptaneClient> primary;
+  std::pair<Uptane::EcuSerial, Uptane::HardwareIdentifier> primary_ecu;
 };
 
 #endif  // AKTUALIZR_LITE_HELPERS

--- a/src/aktualizr_lite/helpers.h
+++ b/src/aktualizr_lite/helpers.h
@@ -25,5 +25,6 @@ struct LiteClient {
 };
 
 bool target_has_tags(const Uptane::Target& t, const std::vector<std::string>& config_tags);
+bool targets_eq(const Uptane::Target& t1, const Uptane::Target& t2, bool compareDockerApps);
 
 #endif  // AKTUALIZR_LITE_HELPERS

--- a/src/aktualizr_lite/helpers.h
+++ b/src/aktualizr_lite/helpers.h
@@ -15,6 +15,20 @@ struct Version {
   bool operator<(const Version& other) { return strverscmp(raw_ver.c_str(), other.raw_ver.c_str()) < 0; }
 };
 
+class Lock {
+ public:
+  Lock(int fd) : fd_(fd) {}
+
+  void release() {
+    if (fd_ != -1) {
+      close(fd_);
+    }
+  }
+
+ private:
+  int fd_;
+};
+
 struct LiteClient {
   LiteClient(Config& config_in);
 
@@ -25,6 +39,9 @@ struct LiteClient {
   std::pair<Uptane::EcuSerial, Uptane::HardwareIdentifier> primary_ecu;
   std::unique_ptr<ReportQueue> report_queue;
   std::shared_ptr<HttpClient> http_client;
+  boost::filesystem::path update_lockfile;
+
+  std::unique_ptr<Lock> getUpdateLock();
 
   void notifyDownloadStarted(const Uptane::Target& t);
   void notifyDownloadFinished(const Uptane::Target& t, bool success);

--- a/src/aktualizr_lite/helpers.h
+++ b/src/aktualizr_lite/helpers.h
@@ -21,6 +21,7 @@ struct LiteClient {
   Config config;
   std::shared_ptr<INvStorage> storage;
   std::shared_ptr<SotaUptaneClient> primary;
+  std::shared_ptr<PackageManagerInterface> package_manager;
   std::pair<Uptane::EcuSerial, Uptane::HardwareIdentifier> primary_ecu;
   std::unique_ptr<ReportQueue> report_queue;
   std::shared_ptr<HttpClient> http_client;

--- a/src/aktualizr_lite/helpers.h
+++ b/src/aktualizr_lite/helpers.h
@@ -39,8 +39,10 @@ struct LiteClient {
   std::pair<Uptane::EcuSerial, Uptane::HardwareIdentifier> primary_ecu;
   std::unique_ptr<ReportQueue> report_queue;
   std::shared_ptr<HttpClient> http_client;
+  boost::filesystem::path download_lockfile;
   boost::filesystem::path update_lockfile;
 
+  std::unique_ptr<Lock> getDownloadLock();
   std::unique_ptr<Lock> getUpdateLock();
 
   void notifyDownloadStarted(const Uptane::Target& t);

--- a/src/aktualizr_lite/helpers.h
+++ b/src/aktualizr_lite/helpers.h
@@ -6,6 +6,7 @@
 #include <string.h>
 
 #include "primary/sotauptaneclient.h"
+#include "uptane/tuf.h"
 
 struct Version {
   std::string raw_ver;
@@ -22,5 +23,7 @@ struct LiteClient {
   std::shared_ptr<SotaUptaneClient> primary;
   std::pair<Uptane::EcuSerial, Uptane::HardwareIdentifier> primary_ecu;
 };
+
+bool target_has_tags(const Uptane::Target& t, const std::vector<std::string>& config_tags);
 
 #endif  // AKTUALIZR_LITE_HELPERS

--- a/src/aktualizr_lite/helpers.h
+++ b/src/aktualizr_lite/helpers.h
@@ -23,6 +23,7 @@ struct LiteClient {
   std::shared_ptr<SotaUptaneClient> primary;
   std::pair<Uptane::EcuSerial, Uptane::HardwareIdentifier> primary_ecu;
   std::unique_ptr<ReportQueue> report_queue;
+  std::shared_ptr<HttpClient> http_client;
 
   void notifyDownloadStarted(const Uptane::Target& t);
   void notifyDownloadFinished(const Uptane::Target& t, bool success);

--- a/src/aktualizr_lite/helpers.h
+++ b/src/aktualizr_lite/helpers.h
@@ -22,8 +22,17 @@ struct LiteClient {
   std::shared_ptr<INvStorage> storage;
   std::shared_ptr<SotaUptaneClient> primary;
   std::pair<Uptane::EcuSerial, Uptane::HardwareIdentifier> primary_ecu;
+  std::unique_ptr<ReportQueue> report_queue;
+
+  void notifyDownloadStarted(const Uptane::Target& t);
+  void notifyDownloadFinished(const Uptane::Target& t, bool success);
+  void notifyInstallStarted(const Uptane::Target& t);
+  void notifyInstallFinished(const Uptane::Target& t, data::ResultCode::Numeric rc);
+
+  void notify(const Uptane::Target& t, std::unique_ptr<ReportEvent> event);
 };
 
+void generate_correlation_id(Uptane::Target& t);
 bool target_has_tags(const Uptane::Target& t, const std::vector<std::string>& config_tags);
 bool targets_eq(const Uptane::Target& t1, const Uptane::Target& t2, bool compareDockerApps);
 

--- a/src/aktualizr_lite/helpers_test.cc
+++ b/src/aktualizr_lite/helpers_test.cc
@@ -51,6 +51,37 @@ TEST(helpers, lite_client_finalize) {
   ASSERT_FALSE(target.MatchHash(LiteClient(config).primary->getCurrent().hashes()[0]));
 }
 
+TEST(helpers, target_has_tags) {
+  auto t = Uptane::Target::Unknown();
+
+  // No tags defined in target:
+  std::vector<std::string> config_tags;
+  ASSERT_TRUE(target_has_tags(t, config_tags));
+  config_tags.push_back("foo");
+  ASSERT_FALSE(target_has_tags(t, config_tags));
+
+  // Set target tags to: premerge, qa
+  auto custom = t.custom_data();
+  custom["tags"].append("premerge");
+  custom["tags"].append("qa");
+  t.updateCustom(custom);
+
+  config_tags.clear();
+  ASSERT_TRUE(target_has_tags(t, config_tags));
+
+  config_tags.push_back("qa");
+  config_tags.push_back("blah");
+  ASSERT_TRUE(target_has_tags(t, config_tags));
+
+  config_tags.clear();
+  config_tags.push_back("premerge");
+  ASSERT_TRUE(target_has_tags(t, config_tags));
+
+  config_tags.clear();
+  config_tags.push_back("foo");
+  ASSERT_FALSE(target_has_tags(t, config_tags));
+}
+
 #ifndef __NO_MAIN__
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);

--- a/src/aktualizr_lite/helpers_test.cc
+++ b/src/aktualizr_lite/helpers_test.cc
@@ -82,6 +82,47 @@ TEST(helpers, target_has_tags) {
   ASSERT_FALSE(target_has_tags(t, config_tags));
 }
 
+TEST(helpers, targets_eq) {
+  auto t1 = Uptane::Target::Unknown();
+  auto t2 = Uptane::Target::Unknown();
+
+  // t1 should equal t2 when there a no docker-apps
+  ASSERT_TRUE(targets_eq(t1, t2, false));
+  ASSERT_TRUE(targets_eq(t1, t2, true));
+
+  auto custom = t1.custom_data();
+  custom["docker_apps"]["app1"]["filename"] = "app1-v1";
+  t1.updateCustom(custom);
+  ASSERT_TRUE(targets_eq(t1, t2, false));  // still equal, ignoring docker-apps
+  ASSERT_FALSE(targets_eq(t1, t2, true));
+
+  custom = t2.custom_data();
+  custom["docker_apps"]["app1"]["filename"] = "app1-v1";
+  t2.updateCustom(custom);
+  ASSERT_TRUE(targets_eq(t1, t2, true));
+
+  custom["docker_apps"]["app1"]["filename"] = "app1-v2";
+  t2.updateCustom(custom);
+  ASSERT_FALSE(targets_eq(t1, t2, true));  // version has changed
+
+  // Get things the same again
+  custom["docker_apps"]["app1"]["filename"] = "app1-v1";
+  t2.updateCustom(custom);
+
+  custom["docker_apps"]["app2"]["filename"] = "app2-v2";
+  t2.updateCustom(custom);
+  ASSERT_FALSE(targets_eq(t1, t2, true));  // t2 has an app that t1 doesn't
+
+  custom = t1.custom_data();
+  custom["docker_apps"]["app2"]["filename"] = "app2-v1";
+  t1.updateCustom(custom);
+  ASSERT_FALSE(targets_eq(t1, t2, true));  // app2 versions differ
+
+  custom["docker_apps"]["app2"]["filename"] = "app2-v2";
+  t1.updateCustom(custom);
+  ASSERT_TRUE(targets_eq(t1, t2, true));
+}
+
 #ifndef __NO_MAIN__
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);

--- a/src/aktualizr_lite/helpers_test.cc
+++ b/src/aktualizr_lite/helpers_test.cc
@@ -123,6 +123,33 @@ TEST(helpers, targets_eq) {
   ASSERT_TRUE(targets_eq(t1, t2, true));
 }
 
+TEST(helpers, locking) {
+  TemporaryDirectory cfg_dir;
+  Config config;
+  config.storage.path = cfg_dir.Path();
+  config.pacman.sysroot = test_sysroot;
+  LiteClient client(config);
+  client.update_lockfile = cfg_dir / "update_lock";
+
+  // 1. Create a lock and hold in inside a thread for a small amount of time
+  std::unique_ptr<Lock> lock = client.getUpdateLock();
+  std::chrono::steady_clock::time_point begin = std::chrono::steady_clock::now();
+  std::thread t([&lock] {
+    std::this_thread::sleep_for(std::chrono::milliseconds{500});
+    lock->release();
+  });
+
+  // 2. Get the lock - this should take a short period of time while its blocked
+  //    by the thread.
+  ASSERT_NE(nullptr, client.getUpdateLock());
+
+  // 3. - make sure some time has passed
+  std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
+  ASSERT_GT(std::chrono::duration_cast<std::chrono::milliseconds>(end - begin).count(), 300);
+
+  t.join();
+}
+
 #ifdef BUILD_DOCKERAPP
 // Ensure we handle config changes of containers at start-up properly
 TEST(helpers, containers_initialize) {

--- a/src/aktualizr_lite/main.cc
+++ b/src/aktualizr_lite/main.cc
@@ -108,6 +108,7 @@ static std::unique_ptr<Uptane::Target> find_target(const std::shared_ptr<SotaUpt
 }
 
 static int do_update(LiteClient &client, Uptane::Target &target) {
+  target.InsertEcu(client.primary_ecu.first, client.primary_ecu.second);
   if (!client.primary->downloadImage(target).first) {
     return 1;
   }

--- a/src/aktualizr_lite/main.cc
+++ b/src/aktualizr_lite/main.cc
@@ -137,43 +137,54 @@ static int get_lock(const char *lockfile) {
   return fd;
 }
 
-static int do_update(LiteClient &client, Uptane::Target &target, const char *lockfile) {
+static data::ResultCode::Numeric do_update(LiteClient &client, Uptane::Target &target, const char *lockfile) {
   target.InsertEcu(client.primary_ecu.first, client.primary_ecu.second);
   generate_correlation_id(target);
   client.notifyDownloadStarted(target);
   if (!client.primary->downloadImage(target).first) {
     client.notifyDownloadFinished(target, false);
-    return 1;
+    return data::ResultCode::Numeric::kDownloadFailed;
   }
   client.notifyDownloadFinished(target, true);
 
   if (client.primary->VerifyTarget(target) != TargetStatus::kGood) {
     client.notifyInstallFinished(target, data::ResultCode::Numeric::kVerificationFailed);
     LOG_ERROR << "Downloaded target is invalid";
+    return data::ResultCode::Numeric::kVerificationFailed;
   }
 
   int lockfd = 0;
   if (lockfile != nullptr && (lockfd = get_lock(lockfile)) < 0) {
-    return 1;
+    return data::ResultCode::Numeric::kInternalError;
   }
+
+  Uptane::Target current = client.primary->getCurrent();
 
   client.notifyInstallStarted(target);
   auto iresult = client.primary->PackageInstall(target);
+  // Make sure the update wasn't just for docker-apps
+  if (iresult.result_code.num_code == data::ResultCode::Numeric::kNeedCompletion) {
+    for (const auto &it : current.hashes()) {
+      if (target.MatchHash(it)) {
+        iresult.result_code.num_code = data::ResultCode::Numeric::kOk;
+        break;
+      }
+    }
+  }
   client.notifyInstallFinished(target, iresult.result_code.num_code);
   if (iresult.result_code.num_code == data::ResultCode::Numeric::kNeedCompletion) {
     LOG_INFO << "Update complete. Please reboot the device to activate";
     client.storage->savePrimaryInstalledVersion(target, InstalledVersionUpdateMode::kPending);
   } else if (iresult.result_code.num_code == data::ResultCode::Numeric::kOk) {
+    LOG_INFO << "Update complete. No reboot needed";
     client.storage->savePrimaryInstalledVersion(target, InstalledVersionUpdateMode::kCurrent);
     close(lockfd);
   } else {
     LOG_ERROR << "Unable to install update: " << iresult.description;
     // let go of the lock since we couldn't update
     close(lockfd);
-    return 1;
   }
-  LOG_INFO << iresult.description;
-  return 0;
+  return iresult.result_code.num_code;
 }
 
 static int update_main(LiteClient &client, const bpo::variables_map &variables_map) {
@@ -190,7 +201,11 @@ static int update_main(LiteClient &client, const bpo::variables_map &variables_m
     return 0;
   }
   LOG_INFO << "Updating to: " << *target;
-  return do_update(client, *target, nullptr);
+  data::ResultCode::Numeric rc = do_update(client, *target, nullptr);
+  if (rc == data::ResultCode::Numeric::kNeedCompletion || rc == data::ResultCode::Numeric::kOk) {
+    return 0;
+  }
+  return 1;
 }
 
 static int daemon_main(LiteClient &client, const bpo::variables_map &variables_map) {
@@ -238,12 +253,16 @@ static int daemon_main(LiteClient &client, const bpo::variables_map &variables_m
     auto target = find_target(client.primary, hwid, client.config.pacman.tags, "latest");
     if (target != nullptr && !targets_eq(*target, current, compareDockerApps)) {
       LOG_INFO << "Updating base image to: " << *target;
-      if (do_update(client, *target, lockfile) == 0) {
-        if (target->MatchHash(current.hashes()[0])) {
-          LOG_INFO << "Update applied, hashes haven't changed";
-          client.storage->savePrimaryInstalledVersion(*target, InstalledVersionUpdateMode::kCurrent);
-          current = *target;
-        } else if (std::system(client.config.bootloader.reboot_command.c_str()) != 0) {
+
+      data::ResultCode::Numeric rc = do_update(client, *target, lockfile);
+      if (rc == data::ResultCode::Numeric::kOk) {
+        current = *target;
+        client.http_client->updateHeader("x-ats-target", current.filename());
+        // Start the loop over to call updateImagesMeta which will update this
+        // device's target name on the server.
+        continue;
+      } else if (rc == data::ResultCode::Numeric::kNeedCompletion) {
+        if (std::system(client.config.bootloader.reboot_command.c_str()) != 0) {
           LOG_ERROR << "Unable to reboot system";
           return 1;
         }

--- a/src/aktualizr_lite/main.cc
+++ b/src/aktualizr_lite/main.cc
@@ -139,11 +139,16 @@ static int get_lock(const char *lockfile) {
 
 static int do_update(LiteClient &client, Uptane::Target &target, const char *lockfile) {
   target.InsertEcu(client.primary_ecu.first, client.primary_ecu.second);
+  generate_correlation_id(target);
+  client.notifyDownloadStarted(target);
   if (!client.primary->downloadImage(target).first) {
+    client.notifyDownloadFinished(target, false);
     return 1;
   }
+  client.notifyDownloadFinished(target, true);
 
   if (client.primary->VerifyTarget(target) != TargetStatus::kGood) {
+    client.notifyInstallFinished(target, data::ResultCode::Numeric::kVerificationFailed);
     LOG_ERROR << "Downloaded target is invalid";
   }
 
@@ -152,7 +157,9 @@ static int do_update(LiteClient &client, Uptane::Target &target, const char *loc
     return 1;
   }
 
+  client.notifyInstallStarted(target);
   auto iresult = client.primary->PackageInstall(target);
+  client.notifyInstallFinished(target, iresult.result_code.num_code);
   if (iresult.result_code.num_code == data::ResultCode::Numeric::kNeedCompletion) {
     LOG_INFO << "Update complete. Please reboot the device to activate";
     client.storage->savePrimaryInstalledVersion(target, InstalledVersionUpdateMode::kPending);
@@ -223,7 +230,11 @@ static int daemon_main(LiteClient &client, const bpo::variables_map &variables_m
     if (target != nullptr && !targets_eq(*target, current, compareDockerApps)) {
       LOG_INFO << "Updating base image to: " << *target;
       if (do_update(client, *target, lockfile) == 0) {
-        if (std::system(client.config.bootloader.reboot_command.c_str()) != 0) {
+        if (target->MatchHash(current.hashes()[0])) {
+          LOG_INFO << "Update applied, hashes haven't changed";
+          client.storage->savePrimaryInstalledVersion(*target, InstalledVersionUpdateMode::kCurrent);
+          current = *target;
+        } else if (std::system(client.config.bootloader.reboot_command.c_str()) != 0) {
           LOG_ERROR << "Unable to reboot system";
           return 1;
         }

--- a/src/aktualizr_lite/main.cc
+++ b/src/aktualizr_lite/main.cc
@@ -65,6 +65,9 @@ static int list_main(LiteClient &client, const bpo::variables_map &unused) {
 
   LOG_INFO << "Updates available to " << hwid << ":";
   for (auto &t : client.primary->allTargets()) {
+    if (!target_has_tags(t, client.config.pacman.tags)) {
+      continue;
+    }
     for (auto const &it : t.hardwareIds()) {
       if (it == hwid) {
         log_info_target("", client.config, t);
@@ -76,7 +79,8 @@ static int list_main(LiteClient &client, const bpo::variables_map &unused) {
 }
 
 static std::unique_ptr<Uptane::Target> find_target(const std::shared_ptr<SotaUptaneClient> &client,
-                                                   Uptane::HardwareIdentifier &hwid, const std::string &version) {
+                                                   Uptane::HardwareIdentifier &hwid,
+                                                   const std::vector<std::string> &tags, const std::string &version) {
   std::unique_ptr<Uptane::Target> rv;
   if (!client->updateImagesMeta()) {
     LOG_WARNING << "Unable to update latest metadata, using local copy";
@@ -89,6 +93,9 @@ static std::unique_ptr<Uptane::Target> find_target(const std::shared_ptr<SotaUpt
   bool find_latest = (version == "latest");
   std::unique_ptr<Uptane::Target> latest = nullptr;
   for (auto &t : client->allTargets()) {
+    if (!target_has_tags(t, tags)) {
+      continue;
+    }
     for (auto const &it : t.hardwareIds()) {
       if (it == hwid) {
         if (find_latest) {
@@ -140,7 +147,11 @@ static int update_main(LiteClient &client, const bpo::variables_map &variables_m
     version = variables_map["update-name"].as<std::string>();
   }
   LOG_INFO << "Finding " << version << " to update to...";
-  auto target = find_target(client.primary, hwid, version);
+  auto target = find_target(client.primary, hwid, client.config.pacman.tags, version);
+  if (target == nullptr) {
+    LOG_INFO << "Already up-to-date";
+    return 0;
+  }
   LOG_INFO << "Updating to: " << *target;
   return do_update(client, *target);
 }

--- a/src/aktualizr_lite/main.cc
+++ b/src/aktualizr_lite/main.cc
@@ -116,11 +116,18 @@ static std::unique_ptr<Uptane::Target> find_target(const std::shared_ptr<SotaUpt
 static data::ResultCode::Numeric do_update(LiteClient &client, Uptane::Target &target) {
   target.InsertEcu(client.primary_ecu.first, client.primary_ecu.second);
   generate_correlation_id(target);
+
+  std::unique_ptr<Lock> lock = client.getDownloadLock();
+  if (lock == nullptr) {
+    return data::ResultCode::Numeric::kInternalError;
+  }
   client.notifyDownloadStarted(target);
   if (!client.primary->downloadImage(target).first) {
+    lock->release();
     client.notifyDownloadFinished(target, false);
     return data::ResultCode::Numeric::kDownloadFailed;
   }
+  lock->release();
   client.notifyDownloadFinished(target, true);
 
   if (client.primary->VerifyTarget(target) != TargetStatus::kGood) {
@@ -129,8 +136,8 @@ static data::ResultCode::Numeric do_update(LiteClient &client, Uptane::Target &t
     return data::ResultCode::Numeric::kVerificationFailed;
   }
 
-  std::unique_ptr<Lock> update_lock = client.getUpdateLock();
-  if (update_lock == nullptr) {
+  lock = client.getUpdateLock();
+  if (lock == nullptr) {
     return data::ResultCode::Numeric::kInternalError;
   }
 
@@ -142,11 +149,11 @@ static data::ResultCode::Numeric do_update(LiteClient &client, Uptane::Target &t
   } else if (iresult.result_code.num_code == data::ResultCode::Numeric::kOk) {
     LOG_INFO << "Update complete. No reboot needed";
     client.storage->savePrimaryInstalledVersion(target, InstalledVersionUpdateMode::kCurrent);
-    update_lock->release();
+    lock->release();
   } else {
     LOG_ERROR << "Unable to install update: " << iresult.description;
     // let go of the lock since we couldn't update
-    update_lock->release();
+    lock->release();
   }
   client.notifyInstallFinished(target, iresult.result_code.num_code);
   return iresult.result_code.num_code;
@@ -187,6 +194,9 @@ static int daemon_main(LiteClient &client, const bpo::variables_map &variables_m
   Uptane::HardwareIdentifier hwid(client.config.provision.primary_ecu_hardware_id);
   if (variables_map.count("update-lockfile") > 0) {
     client.update_lockfile = variables_map["update-lockfile"].as<boost::filesystem::path>();
+  }
+  if (variables_map.count("download-lockfile") > 0) {
+    client.download_lockfile = variables_map["download-lockfile"].as<boost::filesystem::path>();
   }
 
   auto current = client.primary->getCurrent();
@@ -302,6 +312,7 @@ bpo::variables_map parse_options(int argc, char *argv[]) {
       ("update-name", bpo::value<std::string>(), "optional name of the update when running \"update\". default=latest")
       ("interval", bpo::value<uint64_t>(), "Override uptane.polling_secs interval to poll for update when in daemon mode.")
       ("update-lockfile", bpo::value<boost::filesystem::path>(), "If provided, an flock(2) is applied to this file before performing an update in daemon mode")
+      ("download-lockfile", bpo::value<boost::filesystem::path>(), "If provided, an flock(2) is applied to this file before downloading an update in daemon mode")
       ("command", bpo::value<std::string>(), subs.c_str());
   // clang-format on
 

--- a/src/aktualizr_lite/main.cc
+++ b/src/aktualizr_lite/main.cc
@@ -12,13 +12,6 @@
 
 namespace bpo = boost::program_options;
 
-#ifdef BUILD_DOCKERAPP
-#define should_compare_docker_apps(config) \
-  (config.pacman.type == PackageManager::kOstreeDockerApp && !config.pacman.docker_apps.empty())
-#else
-#define should_compare_docker_apps(config) (false)
-#endif
-
 static void log_info_target(const std::string &prefix, const Config &config, const Uptane::Target &t) {
   auto name = t.filename();
   if (t.custom_version().length() > 0) {
@@ -206,6 +199,7 @@ static int daemon_main(LiteClient &client, const bpo::variables_map &variables_m
     LOG_ERROR << "reboot command: " << client.config.bootloader.reboot_command << " is not executable";
     return 1;
   }
+  bool firstLoop = true;
   bool compareDockerApps = should_compare_docker_apps(client.config);
   Uptane::HardwareIdentifier hwid(client.config.provision.primary_ecu_hardware_id);
   const char *lockfile = nullptr;
@@ -232,6 +226,17 @@ static int daemon_main(LiteClient &client, const bpo::variables_map &variables_m
       LOG_WARNING << "Unable to update latest metadata";
       std::this_thread::sleep_for(std::chrono::seconds(10));
       continue;  // There's no point trying to look for an update
+    }
+
+    if (firstLoop) {
+      // On first loop we need to see if we have a config change detected from
+      // from the previous run. We need to make sure we have up-to-date
+      // metadata, so this really needs to be inside the loop.
+      if (!current.MatchTarget(Uptane::Target::Unknown()) && client.dockerAppsChanged()) {
+        do_update(client, current, lockfile);
+      }
+      client.storeDockerParamsDigest();
+      firstLoop = false;
     }
 
     client.primary->reportNetworkInfo();

--- a/src/aktualizr_lite/main.cc
+++ b/src/aktualizr_lite/main.cc
@@ -168,6 +168,10 @@ static int daemon_main(LiteClient &client, const bpo::variables_map &variables_m
     LOG_ERROR << "[uptane]/repo_server is not configured";
     return 1;
   }
+  if (access(client.config.bootloader.reboot_command.c_str(), X_OK) != 0) {
+    LOG_ERROR << "reboot command: " << client.config.bootloader.reboot_command << " is not executable";
+    return 1;
+  }
   bool compareDockerApps = should_compare_docker_apps(client.config);
   Uptane::HardwareIdentifier hwid(client.config.provision.primary_ecu_hardware_id);
 
@@ -190,7 +194,10 @@ static int daemon_main(LiteClient &client, const bpo::variables_map &variables_m
     if (target != nullptr && !targets_eq(*target, current, compareDockerApps)) {
       LOG_INFO << "Updating base image to: " << *target;
       if (do_update(client, *target) == 0) {
-        // TODO reboot
+        if (std::system(client.config.bootloader.reboot_command.c_str()) != 0) {
+          LOG_ERROR << "Unable to reboot system";
+          return 1;
+        }
       }
     }
     std::this_thread::sleep_for(std::chrono::seconds(interval));

--- a/src/aktualizr_lite/main.cc
+++ b/src/aktualizr_lite/main.cc
@@ -11,6 +11,13 @@
 
 namespace bpo = boost::program_options;
 
+#ifdef BUILD_DOCKERAPP
+#define should_compare_docker_apps(config) \
+  (config.pacman.type == PackageManager::kOstreeDockerApp && !config.pacman.docker_apps.empty())
+#else
+#define should_compare_docker_apps(config) (false)
+#endif
+
 static void log_info_target(const std::string &prefix, const Config &config, const Uptane::Target &t) {
   auto name = t.filename();
   if (t.custom_version().length() > 0) {
@@ -156,6 +163,41 @@ static int update_main(LiteClient &client, const bpo::variables_map &variables_m
   return do_update(client, *target);
 }
 
+static int daemon_main(LiteClient &client, const bpo::variables_map &variables_map) {
+  if (client.config.uptane.repo_server.empty()) {
+    LOG_ERROR << "[uptane]/repo_server is not configured";
+    return 1;
+  }
+  bool compareDockerApps = should_compare_docker_apps(client.config);
+  Uptane::HardwareIdentifier hwid(client.config.provision.primary_ecu_hardware_id);
+
+  auto current = client.primary->getCurrent();
+  LOG_INFO << "Active image is: " << current;
+
+  uint64_t interval = client.config.uptane.polling_sec;
+  if (variables_map.count("interval") > 0) {
+    interval = variables_map["interval"].as<uint64_t>();
+  }
+
+  while (true) {
+    LOG_INFO << "Refreshing target metadata";
+    if (!client.primary->updateImagesMeta()) {
+      LOG_WARNING << "Unable to update latest metadata";
+      std::this_thread::sleep_for(std::chrono::seconds(10));
+      continue;  // There's no point trying to look for an update
+    }
+    auto target = find_target(client.primary, hwid, client.config.pacman.tags, "latest");
+    if (target != nullptr && !targets_eq(*target, current, compareDockerApps)) {
+      LOG_INFO << "Updating base image to: " << *target;
+      if (do_update(client, *target) == 0) {
+        // TODO reboot
+      }
+    }
+    std::this_thread::sleep_for(std::chrono::seconds(interval));
+  }
+  return 0;
+}
+
 struct SubCommand {
   const char *name;
   int (*main)(LiteClient &, const bpo::variables_map &);
@@ -164,6 +206,7 @@ static SubCommand commands[] = {
     {"status", status_main},
     {"list", list_main},
     {"update", update_main},
+    {"daemon", daemon_main},
 };
 
 void check_info_options(const bpo::options_description &description, const bpo::variables_map &vm) {
@@ -198,6 +241,7 @@ bpo::variables_map parse_options(int argc, char *argv[]) {
       ("ostree-server", bpo::value<std::string>(), "url of the ostree repository")
       ("primary-ecu-hardware-id", bpo::value<std::string>(), "hardware ID of primary ecu")
       ("update-name", bpo::value<std::string>(), "optional name of the update when running \"update\". default=latest")
+      ("interval", bpo::value<uint64_t>(), "Override uptane.polling_secs interval to poll for update when in daemon mode.")
       ("command", bpo::value<std::string>(), subs.c_str());
   // clang-format on
 

--- a/src/aktualizr_lite/main.cc
+++ b/src/aktualizr_lite/main.cc
@@ -1,5 +1,3 @@
-#include <sys/file.h>
-#include <unistd.h>
 #include <iostream>
 
 #include <boost/filesystem.hpp>
@@ -115,22 +113,7 @@ static std::unique_ptr<Uptane::Target> find_target(const std::shared_ptr<SotaUpt
   throw std::runtime_error("Unable to find update");
 }
 
-static int get_lock(const char *lockfile) {
-  int fd = open(lockfile, O_RDWR | O_CREAT | O_APPEND, 0666);
-  if (fd < 0) {
-    LOG_ERROR << "Unable to open lock file";
-    return -1;
-  }
-  LOG_INFO << "Acquiring lock";
-  if (flock(fd, LOCK_EX) < 0) {
-    LOG_ERROR << "Unable to acquire lock";
-    close(fd);
-    return -1;
-  }
-  return fd;
-}
-
-static data::ResultCode::Numeric do_update(LiteClient &client, Uptane::Target &target, const char *lockfile) {
+static data::ResultCode::Numeric do_update(LiteClient &client, Uptane::Target &target) {
   target.InsertEcu(client.primary_ecu.first, client.primary_ecu.second);
   generate_correlation_id(target);
   client.notifyDownloadStarted(target);
@@ -146,8 +129,8 @@ static data::ResultCode::Numeric do_update(LiteClient &client, Uptane::Target &t
     return data::ResultCode::Numeric::kVerificationFailed;
   }
 
-  int lockfd = 0;
-  if (lockfile != nullptr && (lockfd = get_lock(lockfile)) < 0) {
+  std::unique_ptr<Lock> update_lock = client.getUpdateLock();
+  if (update_lock == nullptr) {
     return data::ResultCode::Numeric::kInternalError;
   }
 
@@ -159,11 +142,11 @@ static data::ResultCode::Numeric do_update(LiteClient &client, Uptane::Target &t
   } else if (iresult.result_code.num_code == data::ResultCode::Numeric::kOk) {
     LOG_INFO << "Update complete. No reboot needed";
     client.storage->savePrimaryInstalledVersion(target, InstalledVersionUpdateMode::kCurrent);
-    close(lockfd);
+    update_lock->release();
   } else {
     LOG_ERROR << "Unable to install update: " << iresult.description;
     // let go of the lock since we couldn't update
-    close(lockfd);
+    update_lock->release();
   }
   client.notifyInstallFinished(target, iresult.result_code.num_code);
   return iresult.result_code.num_code;
@@ -183,7 +166,7 @@ static int update_main(LiteClient &client, const bpo::variables_map &variables_m
     return 0;
   }
   LOG_INFO << "Updating to: " << *target;
-  data::ResultCode::Numeric rc = do_update(client, *target, nullptr);
+  data::ResultCode::Numeric rc = do_update(client, *target);
   if (rc == data::ResultCode::Numeric::kNeedCompletion || rc == data::ResultCode::Numeric::kOk) {
     return 0;
   }
@@ -202,11 +185,8 @@ static int daemon_main(LiteClient &client, const bpo::variables_map &variables_m
   bool firstLoop = true;
   bool compareDockerApps = should_compare_docker_apps(client.config);
   Uptane::HardwareIdentifier hwid(client.config.provision.primary_ecu_hardware_id);
-  const char *lockfile = nullptr;
-  boost::filesystem::path lockfilePath;
   if (variables_map.count("update-lockfile") > 0) {
-    lockfilePath = variables_map["update-lockfile"].as<boost::filesystem::path>();
-    lockfile = lockfilePath.c_str();
+    client.update_lockfile = variables_map["update-lockfile"].as<boost::filesystem::path>();
   }
 
   auto current = client.primary->getCurrent();
@@ -233,7 +213,7 @@ static int daemon_main(LiteClient &client, const bpo::variables_map &variables_m
       // from the previous run. We need to make sure we have up-to-date
       // metadata, so this really needs to be inside the loop.
       if (!current.MatchTarget(Uptane::Target::Unknown()) && client.dockerAppsChanged()) {
-        do_update(client, current, lockfile);
+        do_update(client, current);
       }
       client.storeDockerParamsDigest();
       firstLoop = false;
@@ -257,7 +237,7 @@ static int daemon_main(LiteClient &client, const bpo::variables_map &variables_m
       if (known_target_sha == false && !targets_eq(*target, current, compareDockerApps)) {
         LOG_INFO << "Updating base image to: " << *target;
 
-        data::ResultCode::Numeric rc = do_update(client, *target, lockfile);
+        data::ResultCode::Numeric rc = do_update(client, *target);
         if (rc == data::ResultCode::Numeric::kOk) {
           current = *target;
           client.http_client->updateHeader("x-ats-target", current.filename());

--- a/src/aktualizr_lite/main.cc
+++ b/src/aktualizr_lite/main.cc
@@ -158,20 +158,8 @@ static data::ResultCode::Numeric do_update(LiteClient &client, Uptane::Target &t
     return data::ResultCode::Numeric::kInternalError;
   }
 
-  Uptane::Target current = client.primary->getCurrent();
-
   client.notifyInstallStarted(target);
   auto iresult = client.primary->PackageInstall(target);
-  // Make sure the update wasn't just for docker-apps
-  if (iresult.result_code.num_code == data::ResultCode::Numeric::kNeedCompletion) {
-    for (const auto &it : current.hashes()) {
-      if (target.MatchHash(it)) {
-        iresult.result_code.num_code = data::ResultCode::Numeric::kOk;
-        break;
-      }
-    }
-  }
-  client.notifyInstallFinished(target, iresult.result_code.num_code);
   if (iresult.result_code.num_code == data::ResultCode::Numeric::kNeedCompletion) {
     LOG_INFO << "Update complete. Please reboot the device to activate";
     client.storage->savePrimaryInstalledVersion(target, InstalledVersionUpdateMode::kPending);
@@ -184,6 +172,7 @@ static data::ResultCode::Numeric do_update(LiteClient &client, Uptane::Target &t
     // let go of the lock since we couldn't update
     close(lockfd);
   }
+  client.notifyInstallFinished(target, iresult.result_code.num_code);
   return iresult.result_code.num_code;
 }
 

--- a/src/aktualizr_lite/main.cc
+++ b/src/aktualizr_lite/main.cc
@@ -239,6 +239,10 @@ static int daemon_main(LiteClient &client, const bpo::variables_map &variables_m
 
     auto target = find_target(client.primary, hwid, client.config.pacman.tags, "latest");
     if (target != nullptr) {
+      // do_update sets this information, so we have to set it here so that
+      // targets_eq function can compare them properly
+      target->InsertEcu(client.primary_ecu.first, client.primary_ecu.second);
+
       // This is a workaround for finding and avoiding bad updates after a rollback.
       // Rollback sets the installed version state to none instead of broken, so there is no
       // easy way to find just the bad versions without api/storage changes. As a workaround we

--- a/src/aktualizr_lite/main.cc
+++ b/src/aktualizr_lite/main.cc
@@ -1,3 +1,4 @@
+#include <sys/file.h>
 #include <unistd.h>
 #include <iostream>
 
@@ -121,7 +122,22 @@ static std::unique_ptr<Uptane::Target> find_target(const std::shared_ptr<SotaUpt
   throw std::runtime_error("Unable to find update");
 }
 
-static int do_update(LiteClient &client, Uptane::Target &target) {
+static int get_lock(const char *lockfile) {
+  int fd = open(lockfile, O_RDWR | O_CREAT | O_APPEND, 0666);
+  if (fd < 0) {
+    LOG_ERROR << "Unable to open lock file";
+    return -1;
+  }
+  LOG_INFO << "Acquiring lock";
+  if (flock(fd, LOCK_EX) < 0) {
+    LOG_ERROR << "Unable to acquire lock";
+    close(fd);
+    return -1;
+  }
+  return fd;
+}
+
+static int do_update(LiteClient &client, Uptane::Target &target, const char *lockfile) {
   target.InsertEcu(client.primary_ecu.first, client.primary_ecu.second);
   if (!client.primary->downloadImage(target).first) {
     return 1;
@@ -129,6 +145,10 @@ static int do_update(LiteClient &client, Uptane::Target &target) {
 
   if (client.primary->VerifyTarget(target) != TargetStatus::kGood) {
     LOG_ERROR << "Downloaded target is invalid";
+  }
+
+  int lockfd = 0;
+  if (lockfile != nullptr && (lockfd = get_lock(lockfile)) < 0) {
     return 1;
   }
 
@@ -138,8 +158,11 @@ static int do_update(LiteClient &client, Uptane::Target &target) {
     client.storage->savePrimaryInstalledVersion(target, InstalledVersionUpdateMode::kPending);
   } else if (iresult.result_code.num_code == data::ResultCode::Numeric::kOk) {
     client.storage->savePrimaryInstalledVersion(target, InstalledVersionUpdateMode::kCurrent);
+    close(lockfd);
   } else {
     LOG_ERROR << "Unable to install update: " << iresult.description;
+    // let go of the lock since we couldn't update
+    close(lockfd);
     return 1;
   }
   LOG_INFO << iresult.description;
@@ -160,7 +183,7 @@ static int update_main(LiteClient &client, const bpo::variables_map &variables_m
     return 0;
   }
   LOG_INFO << "Updating to: " << *target;
-  return do_update(client, *target);
+  return do_update(client, *target, nullptr);
 }
 
 static int daemon_main(LiteClient &client, const bpo::variables_map &variables_map) {
@@ -174,6 +197,12 @@ static int daemon_main(LiteClient &client, const bpo::variables_map &variables_m
   }
   bool compareDockerApps = should_compare_docker_apps(client.config);
   Uptane::HardwareIdentifier hwid(client.config.provision.primary_ecu_hardware_id);
+  const char *lockfile = nullptr;
+  boost::filesystem::path lockfilePath;
+  if (variables_map.count("update-lockfile") > 0) {
+    lockfilePath = variables_map["update-lockfile"].as<boost::filesystem::path>();
+    lockfile = lockfilePath.c_str();
+  }
 
   auto current = client.primary->getCurrent();
   LOG_INFO << "Active image is: " << current;
@@ -193,7 +222,7 @@ static int daemon_main(LiteClient &client, const bpo::variables_map &variables_m
     auto target = find_target(client.primary, hwid, client.config.pacman.tags, "latest");
     if (target != nullptr && !targets_eq(*target, current, compareDockerApps)) {
       LOG_INFO << "Updating base image to: " << *target;
-      if (do_update(client, *target) == 0) {
+      if (do_update(client, *target, lockfile) == 0) {
         if (std::system(client.config.bootloader.reboot_command.c_str()) != 0) {
           LOG_ERROR << "Unable to reboot system";
           return 1;
@@ -249,6 +278,7 @@ bpo::variables_map parse_options(int argc, char *argv[]) {
       ("primary-ecu-hardware-id", bpo::value<std::string>(), "hardware ID of primary ecu")
       ("update-name", bpo::value<std::string>(), "optional name of the update when running \"update\". default=latest")
       ("interval", bpo::value<uint64_t>(), "Override uptane.polling_secs interval to poll for update when in daemon mode.")
+      ("update-lockfile", bpo::value<boost::filesystem::path>(), "If provided, an flock(2) is applied to this file before performing an update in daemon mode")
       ("command", bpo::value<std::string>(), subs.c_str());
   // clang-format on
 

--- a/src/aktualizr_lite/main.cc
+++ b/src/aktualizr_lite/main.cc
@@ -223,6 +223,9 @@ static int daemon_main(LiteClient &client, const bpo::variables_map &variables_m
     interval = variables_map["interval"].as<uint64_t>();
   }
 
+  std::vector<Uptane::Target> installed_versions;
+  client.storage->loadPrimaryInstallationLog(&installed_versions, false);
+
   while (true) {
     LOG_INFO << "Refreshing target metadata";
     if (!client.primary->updateImagesMeta()) {
@@ -240,20 +243,27 @@ static int daemon_main(LiteClient &client, const bpo::variables_map &variables_m
     }
 
     auto target = find_target(client.primary, hwid, client.config.pacman.tags, "latest");
-    if (target != nullptr && !targets_eq(*target, current, compareDockerApps)) {
-      LOG_INFO << "Updating base image to: " << *target;
+    if (target != nullptr) {
+      // This is a workaround for finding and avoiding bad updates after a rollback.
+      // Rollback sets the installed version state to none instead of broken, so there is no
+      // easy way to find just the bad versions without api/storage changes. As a workaround we
+      // just check if the version is known (old hash) and not current/pending and abort if so
+      bool known_target_sha = known_local_target(client, *target, installed_versions);
+      if (known_target_sha == false && !targets_eq(*target, current, compareDockerApps)) {
+        LOG_INFO << "Updating base image to: " << *target;
 
-      data::ResultCode::Numeric rc = do_update(client, *target, lockfile);
-      if (rc == data::ResultCode::Numeric::kOk) {
-        current = *target;
-        client.http_client->updateHeader("x-ats-target", current.filename());
-        // Start the loop over to call updateImagesMeta which will update this
-        // device's target name on the server.
-        continue;
-      } else if (rc == data::ResultCode::Numeric::kNeedCompletion) {
-        if (std::system(client.config.bootloader.reboot_command.c_str()) != 0) {
-          LOG_ERROR << "Unable to reboot system";
-          return 1;
+        data::ResultCode::Numeric rc = do_update(client, *target, lockfile);
+        if (rc == data::ResultCode::Numeric::kOk) {
+          current = *target;
+          client.http_client->updateHeader("x-ats-target", current.filename());
+          // Start the loop over to call updateImagesMeta which will update this
+          // device's target name on the server.
+          continue;
+        } else if (rc == data::ResultCode::Numeric::kNeedCompletion) {
+          if (std::system(client.config.bootloader.reboot_command.c_str()) != 0) {
+            LOG_ERROR << "Unable to reboot system";
+            return 1;
+          }
         }
       }
     }

--- a/src/aktualizr_lite/main.cc
+++ b/src/aktualizr_lite/main.cc
@@ -228,6 +228,12 @@ static int daemon_main(LiteClient &client, const bpo::variables_map &variables_m
     }
 
     client.primary->reportNetworkInfo();
+    // reportNetworkInfo already checks `telemetry.report_network`. We need a
+    // way when not running in anonymous mode to decide if we should report
+    // hwinfo to the server. This flag is a good one to (ab)use.
+    if (client.config.telemetry.report_network) {
+      client.primary->reportHwInfo();
+    }
 
     auto target = find_target(client.primary, hwid, client.config.pacman.tags, "latest");
     if (target != nullptr && !targets_eq(*target, current, compareDockerApps)) {

--- a/src/aktualizr_lite/main.cc
+++ b/src/aktualizr_lite/main.cc
@@ -226,6 +226,9 @@ static int daemon_main(LiteClient &client, const bpo::variables_map &variables_m
       std::this_thread::sleep_for(std::chrono::seconds(10));
       continue;  // There's no point trying to look for an update
     }
+
+    client.primary->reportNetworkInfo();
+
     auto target = find_target(client.primary, hwid, client.config.pacman.tags, "latest");
     if (target != nullptr && !targets_eq(*target, current, compareDockerApps)) {
       LOG_INFO << "Updating base image to: " << *target;
@@ -346,6 +349,7 @@ int main(int argc, char *argv[]) {
 
     Config config(commandline_map);
     config.storage.uptane_metadata_path = BasedPath(config.storage.path / "metadata");
+    config.telemetry.report_network = !config.tls.server.empty();
     LOG_DEBUG << "Current directory: " << boost::filesystem::current_path().string();
 
     std::string cmd = commandline_map["command"].as<std::string>();

--- a/src/aktualizr_lite/test_lite.sh
+++ b/src/aktualizr_lite/test_lite.sh
@@ -70,16 +70,16 @@ repo_server = "http://localhost:$port/repo/repo"
 [provision]
 primary_ecu_hardware_id = "hwid-for-test"
 
-[pacman]
-type = "ostree"
-sysroot = "$OSTREE_SYSROOT"
-os = "dummy-os"
-
 [storage]
 type = "sqlite"
 path = "$sota_dir"
 sqldb_path = "sql.db"
 uptane_metadata_path = "$sota_dir/metadata"
+
+[pacman]
+type = "ostree"
+sysroot = "$OSTREE_SYSROOT"
+os = "dummy-os"
 EOF
 
 ## Check that we can do the info command
@@ -114,3 +114,8 @@ if [[ ! "$out" =~ "Active image is: zlast	sha256:$sha" ]] ; then
     echo $out
     exit 1
 fi
+
+## Make sure we obey tags
+echo 'tags = "promoted"' >> $sota_dir/sota.toml
+cd /tmp/
+OSTREE_HASH=$sha LD_PRELOAD=$mock_ostree $valgrind $aklite --loglevel 1 -c $sota_dir/sota.toml update | grep "Already up-to-date"

--- a/src/libaktualizr/bootloader/bootloader.cc
+++ b/src/libaktualizr/bootloader/bootloader.cc
@@ -42,6 +42,11 @@ void Bootloader::setBootOK() const {
         LOG_WARNING << "Failed resetting upgrade_available for u-boot";
       }
       break;
+    case RollbackMode::kFioVB:
+      if (Utils::shell("fiovb_setenv bootcount 0", &sink) != 0) {
+        LOG_WARNING << "Failed resetting bootcount";
+      }
+      break;
     default:
       throw NotImplementedException();
   }
@@ -68,6 +73,14 @@ void Bootloader::updateNotify() const {
         LOG_WARNING << "Failed setting upgrade_available for u-boot";
       }
       if (Utils::shell("fw_setenv rollback 0", &sink) != 0) {
+        LOG_WARNING << "Failed resetting rollback flag";
+      }
+      break;
+    case RollbackMode::kFioVB:
+      if (Utils::shell("fiovb_setenv bootcount 0", &sink) != 0) {
+        LOG_WARNING << "Failed resetting bootcount";
+      }
+      if (Utils::shell("fiovb_setenv rollback 0", &sink) != 0) {
         LOG_WARNING << "Failed resetting rollback flag";
       }
       break;

--- a/src/libaktualizr/bootloader/bootloader_config.cc
+++ b/src/libaktualizr/bootloader/bootloader_config.cc
@@ -10,6 +10,9 @@ std::ostream& operator<<(std::ostream& os, RollbackMode mode) {
     case RollbackMode::kUbootMasked:
       mode_s = "uboot_masked";
       break;
+    case RollbackMode::kFioVB:
+      mode_s = "fiovb";
+      break;
     default:
       mode_s = "none";
       break;
@@ -27,6 +30,8 @@ inline void CopyFromConfig(RollbackMode& dest, const std::string& option_name, c
       dest = RollbackMode::kUbootGeneric;
     } else if (mode == "uboot_masked") {
       dest = RollbackMode::kUbootMasked;
+    } else if (mode == "fiovb") {
+      dest = RollbackMode::kFioVB;
     } else {
       dest = RollbackMode::kBootloaderNone;
     }

--- a/src/libaktualizr/bootloader/bootloader_config.h
+++ b/src/libaktualizr/bootloader/bootloader_config.h
@@ -5,7 +5,7 @@
 #include <boost/property_tree/ini_parser.hpp>
 #include <ostream>
 
-enum class RollbackMode { kBootloaderNone = 0, kUbootGeneric, kUbootMasked };
+enum class RollbackMode { kBootloaderNone = 0, kUbootGeneric, kUbootMasked, kFioVB };
 std::ostream& operator<<(std::ostream& os, RollbackMode mode);
 
 struct BootloaderConfig {

--- a/src/libaktualizr/config/config.h
+++ b/src/libaktualizr/config/config.h
@@ -51,7 +51,7 @@ struct ProvisionConfig {
 };
 
 struct UptaneConfig {
-  uint64_t polling_sec{10u};
+  uint64_t polling_sec{300u};
   std::string director_server;
   std::string repo_server;
   CryptoSource key_source{CryptoSource::kFile};

--- a/src/libaktualizr/config/config.h
+++ b/src/libaktualizr/config/config.h
@@ -100,7 +100,8 @@ class Config : public BaseConfig {
   void updateFromPropertyTree(const boost::property_tree::ptree& pt) override;
   void updateFromCommandLine(const boost::program_options::variables_map& cmd);
 
-  std::vector<boost::filesystem::path> config_dirs_ = {"/usr/lib/sota/conf.d", "/etc/sota/conf.d/"};
+  std::vector<boost::filesystem::path> config_dirs_ = {"/usr/lib/sota/conf.d", "/var/sota/sota.toml",
+                                                       "/etc/sota/conf.d/"};
   bool loglevel_from_cmdline{false};
 };
 

--- a/src/libaktualizr/package_manager/docker_fake.sh
+++ b/src/libaktualizr/package_manager/docker_fake.sh
@@ -15,6 +15,14 @@ if [ "$1" = "render" ] ; then
   cat app1.dockerapp
   exit 0
 fi
+if [ "$1" = "pull" ] ; then
+  echo "DOCKER-COMPOSE PULL"
+  if [ ! -f docker-compose.yml ] ; then
+    echo "Missing docker-compose file!"
+    exit 1
+  fi
+  exit 0
+fi
 if [ "$1" = "up" ] ; then
   echo "DOCKER-COMPOSE UP"
   if [ ! -f docker-compose.yml ] ; then

--- a/src/libaktualizr/package_manager/dockerappmanager.cc
+++ b/src/libaktualizr/package_manager/dockerappmanager.cc
@@ -154,8 +154,20 @@ bool DockerAppManager::fetchTarget(const Uptane::Target &target, Uptane::Fetcher
 }
 
 data::InstallationResult DockerAppManager::install(const Uptane::Target &target) const {
-  auto res = OstreeManager::install(target);
+  data::InstallationResult res;
+  Uptane::Target current = OstreeManager::getCurrent();
+  if (current.sha256Hash() != target.sha256Hash()) {
+    res = OstreeManager::install(target);
+    if (res.result_code.num_code == data::ResultCode::Numeric::kInstallFailed) {
+      LOG_ERROR << "Failed to install OSTree target, skipping Docker Apps";
+      return res;
+    }
+  } else {
+    LOG_INFO << "Target " << target.sha256Hash() << " is same as current";
+    res = data::InstallationResult(data::ResultCode::Numeric::kOk, "OSTree hash already installed, same as current");
+  }
   handleRemovedApps(target);
+
   auto cb = [this](const std::string &app, const Uptane::Target &app_target) {
     LOG_INFO << "Installing " << app << " -> " << app_target;
     return DockerApp(app, config).start();

--- a/src/libaktualizr/package_manager/dockerappmanager.cc
+++ b/src/libaktualizr/package_manager/dockerappmanager.cc
@@ -161,7 +161,15 @@ data::InstallationResult DockerAppManager::install(const Uptane::Target &target)
     return DockerApp(app, config).start();
   };
   if (!iterate_apps(target, cb)) {
-    return data::InstallationResult(data::ResultCode::Numeric::kInstallFailed, "Could not render docker app");
+    res = data::InstallationResult(data::ResultCode::Numeric::kInstallFailed, "Could not render docker app");
+  }
+  if (config.docker_prune) {
+    LOG_INFO << "Pruning unused docker images";
+    // Utils::shell which isn't interactive, we'll use std::system so that
+    // stdout/stderr is streamed while docker sets things up.
+    if (std::system("docker image prune -a -f") != 0) {
+      LOG_WARNING << "Unable to prune unused docker images";
+    }
   }
   return res;
 }

--- a/src/libaktualizr/package_manager/dockerappmanager.cc
+++ b/src/libaktualizr/package_manager/dockerappmanager.cc
@@ -63,6 +63,12 @@ struct DockerApp {
     return true;
   }
 
+  bool fetch() {
+    auto bin = boost::filesystem::canonical(compose_bin).string();
+    std::string cmd("cd " + app_root.string() + " && " + bin + " pull");
+    return std::system(cmd.c_str()) == 0;
+  }
+
   bool start() {
     // Depending on the number and size of the containers in the docker-app,
     // this command can take a bit of time to complete. Rather than using,
@@ -136,7 +142,13 @@ bool DockerAppManager::fetchTarget(const Uptane::Target &target, Uptane::Fetcher
   LOG_INFO << "Looking for DockerApps to fetch";
   auto cb = [this, &fetcher, &keys, progress_cb, token](const std::string &app, const Uptane::Target &app_target) {
     LOG_INFO << "Fetching " << app << " -> " << app_target;
-    return PackageManagerInterface::fetchTarget(app_target, fetcher, keys, progress_cb, token);
+    if (!PackageManagerInterface::fetchTarget(app_target, fetcher, keys, progress_cb, token)) {
+      return false;
+    }
+    std::stringstream ss;
+    ss << *storage_->openTargetFile(app_target);
+    DockerApp dapp(app, config);
+    return dapp.render(ss.str(), true) && dapp.fetch();
   };
   return iterate_apps(target, cb);
 }
@@ -146,10 +158,7 @@ data::InstallationResult DockerAppManager::install(const Uptane::Target &target)
   handleRemovedApps(target);
   auto cb = [this](const std::string &app, const Uptane::Target &app_target) {
     LOG_INFO << "Installing " << app << " -> " << app_target;
-    std::stringstream ss;
-    ss << *storage_->openTargetFile(app_target);
-    DockerApp dapp(app, config);
-    return dapp.render(ss.str(), true) && dapp.start();
+    return DockerApp(app, config).start();
   };
   if (!iterate_apps(target, cb)) {
     return data::InstallationResult(data::ResultCode::Numeric::kInstallFailed, "Could not render docker app");
@@ -185,25 +194,4 @@ void DockerAppManager::handleRemovedApps(const Uptane::Target &target) const {
       }
     }
   }
-}
-
-TargetStatus DockerAppManager::verifyTarget(const Uptane::Target &target) const {
-  TargetStatus status;
-  if (target.IsOstree()) {
-    status = OstreeManager::verifyTarget(target);
-    if (status != TargetStatus::kGood) {
-      return status;
-    }
-  }
-  auto cb = [this](const std::string &app, const Uptane::Target &app_target) {
-    LOG_INFO << "Verifying " << app << " -> " << app_target;
-    std::stringstream ss;
-    ss << *storage_->openTargetFile(app_target);
-    DockerApp dapp(app, config);
-    return dapp.render(ss.str(), false);
-  };
-  if (!iterate_apps(target, cb)) {
-    return TargetStatus::kInvalid;
-  }
-  return TargetStatus::kGood;
 }

--- a/src/libaktualizr/package_manager/dockerappmanager.cc
+++ b/src/libaktualizr/package_manager/dockerappmanager.cc
@@ -157,6 +157,11 @@ data::InstallationResult DockerAppManager::install(const Uptane::Target &target)
   data::InstallationResult res;
   Uptane::Target current = OstreeManager::getCurrent();
   if (current.sha256Hash() != target.sha256Hash()) {
+    // notify the bootloader before installation happens as it is not atomic
+    // and a false notification doesn't hurt with rollback support in place
+    if (bootloader_ != nullptr) {
+      bootloader_->updateNotify();
+    }
     res = OstreeManager::install(target);
     if (res.result_code.num_code == data::ResultCode::Numeric::kInstallFailed) {
       LOG_ERROR << "Failed to install OSTree target, skipping Docker Apps";

--- a/src/libaktualizr/package_manager/dockerappmanager.h
+++ b/src/libaktualizr/package_manager/dockerappmanager.h
@@ -16,7 +16,6 @@ class DockerAppManager : public OstreeManager {
   bool fetchTarget(const Uptane::Target &target, Uptane::Fetcher &fetcher, const KeyManager &keys,
                    FetcherProgressCb progress_cb, const api::FlowControlToken *token) override;
   data::InstallationResult install(const Uptane::Target &target) const override;
-  TargetStatus verifyTarget(const Uptane::Target &target) const override;
   std::string name() const override { return "ostree+docker-app"; }
 
  private:

--- a/src/libaktualizr/package_manager/dockerappmanager_test.cc
+++ b/src/libaktualizr/package_manager/dockerappmanager_test.cc
@@ -5,6 +5,7 @@
 
 #include "config/config.h"
 #include "http/httpclient.h"
+#include "package_manager/ostreemanager.h"
 #include "package_manager/packagemanagerfactory.h"
 #include "package_manager/packagemanagerinterface.h"
 #include "primary/sotauptaneclient.h"
@@ -16,6 +17,26 @@ static std::string repo_server = "http://127.0.0.1:";
 static std::string treehub_server = "http://127.0.0.1:";
 static boost::filesystem::path test_sysroot;
 static boost::filesystem::path uptane_gen;
+
+static struct {
+  int serial{0};
+  std::string rev;
+} ostree_deployment;
+static std::string new_rev;
+
+extern "C" OstreeDeployment* ostree_sysroot_get_booted_deployment(OstreeSysroot* self) {
+  (void)self;
+  static GObjectUniquePtr<OstreeDeployment> dep;
+
+  dep.reset(ostree_deployment_new(0, "dummy-os", ostree_deployment.rev.c_str(), ostree_deployment.serial,
+                                  ostree_deployment.rev.c_str(), ostree_deployment.serial));
+  return dep.get();
+}
+
+extern "C" const char* ostree_deployment_get_csum(OstreeDeployment* self) {
+  (void)self;
+  return ostree_deployment.rev.c_str();
+}
 
 static void progress_cb(const Uptane::Target& target, const std::string& description, unsigned int progress) {
   (void)description;
@@ -56,6 +77,9 @@ TEST(DockerAppManager, DockerApp_Fetch) {
   auto repo = temp_dir.Path();
   auto repod = create_repo(repo);
 
+  ostree_deployment.serial = 1;
+  ostree_deployment.rev = sha;
+
   Config config;
   config.pacman.type = PackageManager::kOstreeDockerApp;
   config.pacman.sysroot = test_sysroot;
@@ -77,6 +101,7 @@ TEST(DockerAppManager, DockerApp_Fetch) {
   boost::filesystem::create_directories(config.pacman.docker_apps_root / "app2");
 
   std::shared_ptr<INvStorage> storage = INvStorage::newStorage(config.storage);
+  storage->savePrimaryInstalledVersion(target, InstalledVersionUpdateMode::kCurrent);
   KeyManager keys(storage, config.keymanagerConfig());
   auto client = std_::make_unique<SotaUptaneClient>(config, storage);
   ASSERT_TRUE(client->updateImagesMeta());

--- a/src/libaktualizr/package_manager/dockerappmanager_test.cc
+++ b/src/libaktualizr/package_manager/dockerappmanager_test.cc
@@ -63,6 +63,7 @@ TEST(DockerAppManager, DockerApp_Fetch) {
   config.pacman.docker_apps.push_back("app1");
   config.pacman.docker_apps.push_back("app2");
   config.pacman.docker_app_bin = config.pacman.docker_compose_bin = "src/libaktualizr/package_manager/docker_fake.sh";
+  config.pacman.docker_prune = false;
   config.pacman.ostree_server = treehub_server;
   config.uptane.repo_server = repo_server + "/repo/repo";
   TemporaryDirectory dir;

--- a/src/libaktualizr/package_manager/dockerappmanager_test.cc
+++ b/src/libaktualizr/package_manager/dockerappmanager_test.cc
@@ -104,7 +104,8 @@ TEST(DockerAppManager, DockerApp_Fetch) {
   ASSERT_TRUE(boost::filesystem::exists(config.pacman.docker_apps_root / "docker-compose-down-called"));
 
   setenv("DOCKER_APP_FAIL", "1", 1);
-  ASSERT_EQ(TargetStatus::kInvalid, client->VerifyTarget(target));
+  result = client->package_manager_->fetchTarget(target, *(client->uptane_fetcher), keys, progress_cb, nullptr);
+  ASSERT_FALSE(result);
 }
 
 #ifndef __NO_MAIN__

--- a/src/libaktualizr/package_manager/packagemanagerconfig.cc
+++ b/src/libaktualizr/package_manager/packagemanagerconfig.cc
@@ -33,11 +33,16 @@ void PackageConfig::updateFromPropertyTree(const boost::property_tree::ptree& pt
   CopyFromConfig(ostree_server, "ostree_server", pt);
   CopyFromConfig(packages_file, "packages_file", pt);
   CopyFromConfig(fake_need_reboot, "fake_need_reboot", pt);
+  std::string val;
+  CopyFromConfig(val, "tags", pt);
+  if (val.length() > 0) {
+    boost::split(tags, val, boost::is_any_of(", "), boost::token_compress_on);
+    val.clear();  // this is re-used by docker_apps
+  }
 #ifdef BUILD_DOCKERAPP
   CopyFromConfig(docker_apps_root, "docker_apps_root", pt);
   CopyFromConfig(docker_compose_bin, "docker_compose_bin", pt);
   CopyFromConfig(docker_prune, "docker_prune", pt);
-  std::string val;
   CopyFromConfig(val, "docker_apps", pt);
   if (val.length() > 0) {
     // token_compress_on allows lists like: "foo,bar", "foo, bar", or "foo bar"
@@ -55,6 +60,7 @@ void PackageConfig::writeToStream(std::ostream& out_stream) const {
   writeOption(out_stream, ostree_server, "ostree_server");
   writeOption(out_stream, packages_file, "packages_file");
   writeOption(out_stream, fake_need_reboot, "fake_need_reboot");
+  writeOption(out_stream, boost::algorithm::join(tags, ","), "tags");
 #ifdef BUILD_DOCKERAPP
   writeOption(out_stream, boost::algorithm::join(docker_apps, ","), "docker_apps");
   writeOption(out_stream, docker_apps_root, "docker_apps_root");

--- a/src/libaktualizr/package_manager/packagemanagerconfig.cc
+++ b/src/libaktualizr/package_manager/packagemanagerconfig.cc
@@ -36,6 +36,7 @@ void PackageConfig::updateFromPropertyTree(const boost::property_tree::ptree& pt
 #ifdef BUILD_DOCKERAPP
   CopyFromConfig(docker_apps_root, "docker_apps_root", pt);
   CopyFromConfig(docker_compose_bin, "docker_compose_bin", pt);
+  CopyFromConfig(docker_prune, "docker_prune", pt);
   std::string val;
   CopyFromConfig(val, "docker_apps", pt);
   if (val.length() > 0) {
@@ -60,5 +61,6 @@ void PackageConfig::writeToStream(std::ostream& out_stream) const {
   writeOption(out_stream, docker_app_params, "docker_app_params");
   writeOption(out_stream, docker_app_bin, "docker_app_bin");
   writeOption(out_stream, docker_compose_bin, "docker_compose_bin");
+  writeOption(out_stream, docker_prune, "docker_prune");
 #endif
 }

--- a/src/libaktualizr/package_manager/packagemanagerconfig.h
+++ b/src/libaktualizr/package_manager/packagemanagerconfig.h
@@ -27,6 +27,7 @@ struct PackageConfig {
   boost::filesystem::path docker_app_params;
   boost::filesystem::path docker_app_bin{"/usr/bin/docker-app"};
   boost::filesystem::path docker_compose_bin{"/usr/bin/docker-compose"};
+  bool docker_prune{true};
 #endif
 
   // Options for simulation (to be used with kNone)

--- a/src/libaktualizr/package_manager/packagemanagerconfig.h
+++ b/src/libaktualizr/package_manager/packagemanagerconfig.h
@@ -20,6 +20,7 @@ struct PackageConfig {
   boost::filesystem::path sysroot;
   std::string ostree_server;
   boost::filesystem::path packages_file{"/usr/package.manifest"};
+  std::vector<std::string> tags;
 
 #ifdef BUILD_DOCKERAPP
   std::vector<std::string> docker_apps;

--- a/src/libaktualizr/primary/sotauptaneclient.cc
+++ b/src/libaktualizr/primary/sotauptaneclient.cc
@@ -583,9 +583,11 @@ std::pair<bool, Uptane::Target> SotaUptaneClient::downloadImage(const Uptane::Ta
   // TODO: support downloading encrypted targets from director
 
   const std::string &correlation_id = director_repo.getCorrelationId();
-  // send an event for all ecus that are touched by this target
-  for (const auto &ecu : target.ecus()) {
-    report_queue->enqueue(std_::make_unique<EcuDownloadStartedReport>(ecu.first, correlation_id));
+  if (correlation_id.size() > 0) {
+    // send an event for all ecus that are touched by this target
+    for (const auto &ecu : target.ecus()) {
+      report_queue->enqueue(std_::make_unique<EcuDownloadStartedReport>(ecu.first, correlation_id));
+    }
   }
 
   KeyManager keys(storage, config.keymanagerConfig());
@@ -620,10 +622,12 @@ std::pair<bool, Uptane::Target> SotaUptaneClient::downloadImage(const Uptane::Ta
     success = true;
   }
 
-  // send this asynchronously before `sendEvent`, so that the report timestamp
-  // would not be delayed by callbacks on events
-  for (const auto &ecu : target.ecus()) {
-    report_queue->enqueue(std_::make_unique<EcuDownloadCompletedReport>(ecu.first, correlation_id, success));
+  if (correlation_id.size() > 0) {
+    // send this asynchronously before `sendEvent`, so that the report timestamp
+    // would not be delayed by callbacks on events
+    for (const auto &ecu : target.ecus()) {
+      report_queue->enqueue(std_::make_unique<EcuDownloadCompletedReport>(ecu.first, correlation_id, success));
+    }
   }
 
   sendEvent<event::DownloadTargetComplete>(target, success);

--- a/src/libaktualizr/primary/sotauptaneclient.h
+++ b/src/libaktualizr/primary/sotauptaneclient.h
@@ -72,7 +72,8 @@ class SotaUptaneClient {
   Uptane::LazyTargetsList allTargets() const;
   Uptane::Target getCurrent() const { return package_manager_->getCurrent(); }
 
-  bool updateImagesMeta();  // TODO: make private once aktualizr has a proper TUF API
+  bool updateImagesMeta();      // TODO: make private once aktualizr has a proper TUF API
+  void initializePrimaryEcu();  // TODO: make private once aktualizr has a proper TUF API
   bool checkImagesMetaOffline();
   data::InstallationResult PackageInstall(const Uptane::Target &target);
   TargetStatus VerifyTarget(const Uptane::Target &target) const { return package_manager_->verifyTarget(target); }

--- a/src/libaktualizr/primary/sotauptaneclient.h
+++ b/src/libaktualizr/primary/sotauptaneclient.h
@@ -78,6 +78,7 @@ class SotaUptaneClient {
   data::InstallationResult PackageInstall(const Uptane::Target &target);
   TargetStatus VerifyTarget(const Uptane::Target &target) const { return package_manager_->verifyTarget(target); }
   void reportNetworkInfo();
+  void reportHwInfo();
 
  protected:
   void addSecondary(const std::shared_ptr<Uptane::SecondaryInterface> &sec);
@@ -124,7 +125,6 @@ class SotaUptaneClient {
                                                 const Uptane::EcuSerial &ecu_id);
   data::InstallationResult PackageInstallSetResult(const Uptane::Target &target);
   void finalizeAfterReboot();
-  void reportHwInfo();
   void reportInstalledPackages();
   void reportAktualizrConfiguration();
   void verifySecondaries();

--- a/src/libaktualizr/primary/sotauptaneclient.h
+++ b/src/libaktualizr/primary/sotauptaneclient.h
@@ -77,6 +77,7 @@ class SotaUptaneClient {
   bool checkImagesMetaOffline();
   data::InstallationResult PackageInstall(const Uptane::Target &target);
   TargetStatus VerifyTarget(const Uptane::Target &target) const { return package_manager_->verifyTarget(target); }
+  void reportNetworkInfo();
 
  protected:
   void addSecondary(const std::shared_ptr<Uptane::SecondaryInterface> &sec);
@@ -125,7 +126,6 @@ class SotaUptaneClient {
   void finalizeAfterReboot();
   void reportHwInfo();
   void reportInstalledPackages();
-  void reportNetworkInfo();
   void reportAktualizrConfiguration();
   void verifySecondaries();
   void sendMetadataToEcus(const std::vector<Uptane::Target> &targets);

--- a/src/libaktualizr/uptane/tuf.h
+++ b/src/libaktualizr/uptane/tuf.h
@@ -262,6 +262,10 @@ class Target {
   void setUri(std::string uri) { uri_ = std::move(uri); };
   bool MatchHash(const Hash &hash) const;
 
+  void InsertEcu(const EcuSerial &ecuIdentifier, const HardwareIdentifier &hwid) {
+    ecus_.insert({ecuIdentifier, hwid});
+  }
+
   bool IsForEcu(const EcuSerial &ecuIdentifier) const {
     return (std::find_if(ecus_.cbegin(), ecus_.cend(), [&ecuIdentifier](std::pair<EcuSerial, HardwareIdentifier> pair) {
               return pair.first == ecuIdentifier;

--- a/src/libaktualizr/utilities/config_utils.h
+++ b/src/libaktualizr/utilities/config_utils.h
@@ -164,7 +164,8 @@ class BaseConfig {
     }
   }
 
-  std::vector<boost::filesystem::path> config_dirs_ = {"/usr/lib/sota/conf.d", "/etc/sota/conf.d/"};
+  std::vector<boost::filesystem::path> config_dirs_ = {"/usr/lib/sota/conf.d", "/var/sota/sota.toml",
+                                                       "/etc/sota/conf.d/"};
 };
 
 #endif  // CONFIG_UTILS_H_

--- a/src/libaktualizr/utilities/sig_handler.cc
+++ b/src/libaktualizr/utilities/sig_handler.cc
@@ -1,7 +1,7 @@
 #include "sig_handler.h"
 #include "logging/logging.h"
 
-std::atomic<bool> SigHandler::signal_marker_;
+std::atomic_uint SigHandler::signal_marker_;
 std::mutex SigHandler::exit_m_;
 std::condition_variable SigHandler::exit_cv_;
 bool SigHandler::exit_flag_;
@@ -31,7 +31,7 @@ void SigHandler::start(const std::function<void()>& on_signal) {
   polling_thread_ = boost::thread([on_signal]() {
     std::unique_lock<std::mutex> l(exit_m_);
     while (true) {
-      bool got_signal = signal_marker_.exchange(false);
+      auto got_signal = signal_marker_.exchange(0);
 
       if (got_signal) {
         on_signal();
@@ -49,7 +49,7 @@ void SigHandler::signal(int sig) { ::signal(sig, signal_handler); }
 
 void SigHandler::signal_handler(int sig) {
   (void)sig;
-  bool v = false;
+  unsigned int v = 0;
   // put true if currently set to false
-  SigHandler::signal_marker_.compare_exchange_strong(v, true);
+  SigHandler::signal_marker_.compare_exchange_strong(v, 1);
 }

--- a/src/libaktualizr/utilities/sig_handler.h
+++ b/src/libaktualizr/utilities/sig_handler.h
@@ -31,7 +31,7 @@ class SigHandler {
   static void signal_handler(int sig);
 
   boost::thread polling_thread_;
-  static std::atomic<bool> signal_marker_;
+  static std::atomic_uint signal_marker_;
 
   static std::mutex exit_m_;
   static std::condition_variable exit_cv_;


### PR DESCRIPTION
Rebase our changes onto the 2020.1 release of aktualizr. Notable changes:

 * remove running apps change was merged upstream
 * doc updates (does not affect us)
 * improvements to handling of secondaries (does not affect us) 
 * clean up of meta data fetching logic
 * don't fetch snapshot or target meta data if we have the latest already (nice improvement for our users)
 * libaktualizr now built as shared library

I also tried to move more our "toup" patches to the front of the queue. Some are a little hard to do easily though. Additonally some "fixup" patches were squashed to help keep the history clean.