### PR TITLE
Add a "current-target" file

### DIFF
--- a/src/aktualizr_lite/helpers.h
+++ b/src/aktualizr_lite/helpers.h
@@ -53,6 +53,7 @@ struct LiteClient {
   void notify(const Uptane::Target& t, std::unique_ptr<ReportEvent> event);
   bool dockerAppsChanged();
   void storeDockerParamsDigest();
+  void writeCurrentTarget(const Uptane::Target& t);
 };
 
 bool should_compare_docker_apps(const Config& config);

--- a/src/aktualizr_lite/test_lite.sh
+++ b/src/aktualizr_lite/test_lite.sh
@@ -114,6 +114,8 @@ if [[ ! "$out" =~ "Active image is: zlast	sha256:$sha" ]] ; then
     echo $out
     exit 1
 fi
+source ${sota_dir}/current-target
+[ "$TARGET_NAME" = "zlast" ] || (echo current-target wrong: $TARGET_NAME != zlast; exit 1)
 
 ## Make sure we obey tags
 echo 'tags = "promoted"' >> $sota_dir/sota.toml


### PR DESCRIPTION
Its a bit of a pain having to run `aktualizr-lite status` to find out
what's currently running. Its even more painful if a container wants to
know the current version. With this change, you can cat this file to
find the value and containers can bind-mount it to view.

Signed-off-by: Andy Doan <andy@foundries.io>