### PR TITLE
libaktualizr: dockerappmanager: dont prune label fio-no-prune

### DIFF
--- a/src/libaktualizr/package_manager/dockerappmanager.cc
+++ b/src/libaktualizr/package_manager/dockerappmanager.cc
@@ -184,7 +184,7 @@ data::InstallationResult DockerAppManager::install(const Uptane::Target &target)
     LOG_INFO << "Pruning unused docker images";
     // Utils::shell which isn't interactive, we'll use std::system so that
     // stdout/stderr is streamed while docker sets things up.
-    if (std::system("docker image prune -a -f") != 0) {
+    if (std::system("docker image prune -a -f --filter=\"label!=fio-no-prune\"") != 0) {
       LOG_WARNING << "Unable to prune unused docker images";
     }
   }


### PR DESCRIPTION
Let's create a way of preserving images which are not currently
being used by marking them with the following label:
fio-no-prune=1

This would allow a crazy use-case where a subscriber wants to
dynamically handle a manual docker image that isn't being managed
via their factory docker-apps.

Signed-off-by: Michael Scott <mike@foundries.io>