### PR TITLE
[fio extras] bootloader: fiovb: also manage upgrade_available

### DIFF
--- a/src/libaktualizr/bootloader/bootloader.cc
+++ b/src/libaktualizr/bootloader/bootloader.cc
@@ -46,6 +46,9 @@ void Bootloader::setBootOK() const {
       if (Utils::shell("fiovb_setenv bootcount 0", &sink) != 0) {
         LOG_WARNING << "Failed resetting bootcount";
       }
+      if (Utils::shell("fiovb_setenv upgrade_available 0", &sink) != 0) {
+        LOG_WARNING << "Failed resetting upgrade_available";
+      }
       break;
     default:
       throw NotImplementedException();
@@ -79,6 +82,9 @@ void Bootloader::updateNotify() const {
     case RollbackMode::kFioVB:
       if (Utils::shell("fiovb_setenv bootcount 0", &sink) != 0) {
         LOG_WARNING << "Failed resetting bootcount";
+      }
+      if (Utils::shell("fiovb_setenv upgrade_available 1", &sink) != 0) {
+        LOG_WARNING << "Failed setting upgrade_available";
       }
       if (Utils::shell("fiovb_setenv rollback 0", &sink) != 0) {
         LOG_WARNING << "Failed resetting rollback flag";


### PR DESCRIPTION
As done for u-boot masked, manage the upgrade_available variable logic
via fiovb, to help improving the bootcount management in u-boot.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>