### PR TITLE
[fio extras] storage: make storage TUF aware

### DIFF
--- a/src/libaktualizr/storage/invstorage.cc
+++ b/src/libaktualizr/storage/invstorage.cc
@@ -91,6 +91,10 @@ void INvStorage::importUpdateCertificate(const boost::filesystem::path& base_pat
 
 void INvStorage::importPrimaryKeys(const boost::filesystem::path& base_path, const utils::BasedPath& import_pubkey_path,
                                    const utils::BasedPath& import_privkey_path) {
+  if (client_ == StorageClient::kTUF) {
+    LOG_DEBUG << "TUF instance, primary keys not required";
+    return;
+  }
   if (import_pubkey_path.empty() || import_privkey_path.empty()) {
     LOG_ERROR << "Couldn`t import data: empty path received";
     return;
@@ -143,7 +147,7 @@ void INvStorage::importData(const ImportConfig& import_config) {
   importInstalledVersions(import_config.base_path);
 }
 
-std::shared_ptr<INvStorage> INvStorage::newStorage(const StorageConfig& config, const bool readonly) {
+std::shared_ptr<INvStorage> INvStorage::newStorage(const StorageConfig& config, const bool readonly, StorageClient client) {
   switch (config.type) {
     case StorageType::kSqlite: {
       boost::filesystem::path db_path = config.sqldb_path.get(config.path);
@@ -162,7 +166,7 @@ std::shared_ptr<INvStorage> INvStorage::newStorage(const StorageConfig& config, 
         old_config.type = StorageType::kFileSystem;
         old_config.path = config.path;
 
-        auto sql_storage = std::make_shared<SQLStorage>(config, readonly);
+        auto sql_storage = std::make_shared<SQLStorage>(config, readonly, client);
         FSStorageRead fs_storage(old_config);
         INvStorage::FSSToSQLS(fs_storage, *sql_storage);
         return sql_storage;
@@ -172,7 +176,7 @@ std::shared_ptr<INvStorage> INvStorage::newStorage(const StorageConfig& config, 
       } else {
         LOG_INFO << "Use existing SQL storage: " << db_path;
       }
-      return std::make_shared<SQLStorage>(config, readonly);
+      return std::make_shared<SQLStorage>(config, readonly, client);
     }
     case StorageType::kFileSystem:
     default:

--- a/src/libaktualizr/storage/invstorage.h
+++ b/src/libaktualizr/storage/invstorage.h
@@ -17,6 +17,8 @@ class INvStorage;
 class FSStorageRead;
 class SQLStorage;
 
+enum class StorageClient { kUptane = 0, kTUF = 1 };
+
 using store_data_t = void (INvStorage::*)(const std::string&);
 using load_data_t = bool (INvStorage::*)(std::string*) const;
 
@@ -42,7 +44,7 @@ enum class InstalledVersionUpdateMode { kNone, kCurrent, kPending };
 // store* functions normally write the complete content. save* functions just add an entry.
 class INvStorage {
  public:
-  explicit INvStorage(StorageConfig config) : config_(std::move(config)) {}
+  explicit INvStorage(StorageConfig config, StorageClient client = StorageClient::kUptane): config_(std::move(config)), client_(client) { }
   virtual ~INvStorage() = default;
   virtual StorageType type() = 0;
   virtual void storePrimaryKeys(const std::string& public_key, const std::string& private_key) = 0;
@@ -146,7 +148,8 @@ class INvStorage {
   virtual void cleanUp() = 0;
 
   // Special constructors and utilities
-  static std::shared_ptr<INvStorage> newStorage(const StorageConfig& config, bool readonly = false);
+  static std::shared_ptr<INvStorage> newStorage(const StorageConfig& config, bool readonly = false,
+                                                StorageClient client = StorageClient::kUptane);
   static void FSSToSQLS(FSStorageRead& fs_storage, SQLStorage& sql_storage);
   static bool fsReadInstalledVersions(const boost::filesystem::path& filename,
                                       std::vector<Uptane::Target>* installed_versions, size_t* current_version);
@@ -176,6 +179,8 @@ class INvStorage {
 
  protected:
   const StorageConfig config_;
+ private:
+  StorageClient client_;
 };
 
 #endif  // INVSTORAGE_H_

--- a/src/libaktualizr/storage/sqlstorage.cc
+++ b/src/libaktualizr/storage/sqlstorage.cc
@@ -58,11 +58,11 @@ void SQLStorage::cleanMetaVersion(Uptane::RepositoryType repo, const Uptane::Rol
   db.commitTransaction();
 }
 
-SQLStorage::SQLStorage(const StorageConfig& config, bool readonly)
+SQLStorage::SQLStorage(const StorageConfig& config, bool readonly, StorageClient storage_client)
     : SQLStorageBase(config.sqldb_path.get(config.path), readonly, libaktualizr_schema_migrations,
                      libaktualizr_schema_rollback_migrations, libaktualizr_current_schema,
                      libaktualizr_current_schema_version),
-      INvStorage(config) {
+      INvStorage(config, storage_client) {
   try {
     cleanMetaVersion(Uptane::RepositoryType::Director(), Uptane::Role::Root());
     cleanMetaVersion(Uptane::RepositoryType::Image(), Uptane::Role::Root());

--- a/src/libaktualizr/storage/sqlstorage.h
+++ b/src/libaktualizr/storage/sqlstorage.h
@@ -19,7 +19,7 @@ class SQLStorage : public SQLStorageBase, public INvStorage {
  public:
   friend class SQLTargetWHandle;
   friend class SQLTargetRHandle;
-  explicit SQLStorage(const StorageConfig& config, bool readonly);
+  explicit SQLStorage(const StorageConfig& config, bool readonly, StorageClient storage_client = StorageClient::kUptane);
   ~SQLStorage() override = default;
   void storePrimaryKeys(const std::string& public_key, const std::string& private_key) override;
   bool loadPrimaryKeys(std::string* public_key, std::string* private_key) const override;


### PR DESCRIPTION
Lite/TUF has different storage requirements than Uptane; however we
want to keep all code common and backwards compatible so we can
benefit from existing regression tests.

To that end, this commit makes the storage subsytem aware that it is
executing for TUF client.
That allows us to taylor it to the TUF needs.

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>