### PR TITLE
[fio extras] aktualizr_get: set default storage (TUF)

### DIFF
--- a/src/aktualizr_get/get.cc
+++ b/src/aktualizr_get/get.cc
@@ -3,8 +3,9 @@
 #include "http/httpclient.h"
 #include "storage/invstorage.h"
 
-std::string aktualizrGet(Config &config, const std::string &url, const std::vector<std::string> &headers) {
-  auto storage = INvStorage::newStorage(config.storage);
+std::string aktualizrGet(Config &config, const std::string &url, const std::vector<std::string> &headers,
+                         StorageClient storage_client) {
+  auto storage = INvStorage::newStorage(config.storage, false, storage_client);
   storage->importData(config.import);
 
   auto client = std_::make_unique<HttpClient>(&headers);

--- a/src/aktualizr_get/get.h
+++ b/src/aktualizr_get/get.h
@@ -2,7 +2,9 @@
 #define AKTUALIZR_GET_HELPERS
 
 #include "libaktualizr/config.h"
+#include "storage/invstorage.h"
 
-std::string aktualizrGet(Config &config, const std::string &url, const std::vector<std::string> &headers);
+std::string aktualizrGet(Config &config, const std::string &url, const std::vector<std::string> &headers,
+                         StorageClient storage_client = StorageClient::kUptane);
 
 #endif  // AKTUALIZR_GET_HELPERS

--- a/src/libaktualizr/storage/invstorage.cc
+++ b/src/libaktualizr/storage/invstorage.cc
@@ -147,7 +147,8 @@ void INvStorage::importData(const ImportConfig& import_config) {
   importInstalledVersions(import_config.base_path);
 }
 
-std::shared_ptr<INvStorage> INvStorage::newStorage(const StorageConfig& config, const bool readonly, StorageClient client) {
+std::shared_ptr<INvStorage> INvStorage::newStorage(const StorageConfig& config, const bool readonly,
+                                                   StorageClient client) {
   switch (config.type) {
     case StorageType::kSqlite: {
       boost::filesystem::path db_path = config.sqldb_path.get(config.path);

--- a/src/libaktualizr/storage/invstorage.h
+++ b/src/libaktualizr/storage/invstorage.h
@@ -44,7 +44,8 @@ enum class InstalledVersionUpdateMode { kNone, kCurrent, kPending };
 // store* functions normally write the complete content. save* functions just add an entry.
 class INvStorage {
  public:
-  explicit INvStorage(StorageConfig config, StorageClient client = StorageClient::kUptane): config_(std::move(config)), client_(client) { }
+  explicit INvStorage(StorageConfig config, StorageClient client = StorageClient::kUptane)
+      : config_(std::move(config)), client_(client) {}
   virtual ~INvStorage() = default;
   virtual StorageType type() = 0;
   virtual void storePrimaryKeys(const std::string& public_key, const std::string& private_key) = 0;
@@ -179,6 +180,7 @@ class INvStorage {
 
  protected:
   const StorageConfig config_;
+
  private:
   StorageClient client_;
 };

--- a/src/libaktualizr/storage/sqlstorage.h
+++ b/src/libaktualizr/storage/sqlstorage.h
@@ -19,7 +19,8 @@ class SQLStorage : public SQLStorageBase, public INvStorage {
  public:
   friend class SQLTargetWHandle;
   friend class SQLTargetRHandle;
-  explicit SQLStorage(const StorageConfig& config, bool readonly, StorageClient storage_client = StorageClient::kUptane);
+  explicit SQLStorage(const StorageConfig& config, bool readonly,
+                      StorageClient storage_client = StorageClient::kUptane);
   ~SQLStorage() override = default;
   void storePrimaryKeys(const std::string& public_key, const std::string& private_key) override;
   bool loadPrimaryKeys(std::string* public_key, std::string* private_key) const override;


### PR DESCRIPTION
Add an additional parameter to set the storage client (tuf/uptane)

By default, aktualizer-get will be set to TUF while the tests will be
set to Uptane; this is because we do not want to affect the default
test suite.

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>