### PR TITLE
[FIO toup] sig_handler: fix build warning

### DIFF
--- a/src/libaktualizr/utilities/sig_handler.cc
+++ b/src/libaktualizr/utilities/sig_handler.cc
@@ -36,7 +36,7 @@ void SigHandler::start(const std::function<void()>& on_signal) {
     while (true) {
       auto got_signal = signal_marker_.exchange(0);
 
-      if (got_signal) {
+      if (static_cast<bool>(got_signal)) {
         on_signal();
         return;
       }


### PR DESCRIPTION
Fixes 6aeee363 ("sig_handler: prefer atomic_uint instead of atomic<bool>")