### PR TITLE
[fio extras] pkcs11: allow external p11 engine

### DIFF
--- a/src/libaktualizr/crypto/keymanager.cc
+++ b/src/libaktualizr/crypto/keymanager.cc
@@ -18,10 +18,15 @@ static constexpr bool built_with_p11 = true;
 static constexpr bool built_with_p11 = false;
 #endif
 
-KeyManager::KeyManager(std::shared_ptr<INvStorage> backend, KeyManagerConfig config)
+KeyManager::KeyManager(std::shared_ptr<INvStorage> backend, KeyManagerConfig config,
+                       const std::shared_ptr<P11EngineGuard> &p11)
     : backend_(std::move(backend)), config_(std::move(config)) {
   if (built_with_p11) {
-    p11_ = std_::make_unique<P11EngineGuard>(config_.p11);
+    if (!p11_) {
+      p11_ = std::make_shared<P11EngineGuard>(config_.p11);
+    } else {
+      p11_ = p11;
+    }
   }
 }
 

--- a/src/libaktualizr/crypto/keymanager.h
+++ b/src/libaktualizr/crypto/keymanager.h
@@ -15,7 +15,8 @@ class KeyManager {
   // std::string RSAPSSSign(const std::string &message);
   // Contains the logic from HttpClient::setCerts()
   void copyCertsToCurl(HttpInterface &http) const;
-  KeyManager(std::shared_ptr<INvStorage> backend, KeyManagerConfig config);
+  KeyManager(std::shared_ptr<INvStorage> backend, KeyManagerConfig config,
+             const std::shared_ptr<P11EngineGuard> &p11 = nullptr);
   void loadKeys(const std::string *pkey_content = nullptr, const std::string *cert_content = nullptr,
                 const std::string *ca_content = nullptr);
   std::string getPkeyFile() const;
@@ -36,7 +37,7 @@ class KeyManager {
  private:
   std::shared_ptr<INvStorage> backend_;
   const KeyManagerConfig config_;
-  std::unique_ptr<P11EngineGuard> p11_;
+  std::shared_ptr<P11EngineGuard> p11_;
   std::unique_ptr<TemporaryFile> tmp_pkey_file;
   std::unique_ptr<TemporaryFile> tmp_cert_file;
   std::unique_ptr<TemporaryFile> tmp_ca_file;


### PR DESCRIPTION
The p11 engine is designed in a such way that it will work only a
singleton within a single process. At the same time, KeyManager cannot
be a singleton since it depends on Storage which can be/is recreated for
each LiteClient instance. Thus, instantiation of P11 Engine out of the
KeyManager scope allows making it a process-wide singleton while
KeyManager itself can be recreated/instantiated many times.

Signed-off-by: Mike Sul <mike.sul@foundries.io>