### PR TITLE
[fio extras]: allow updating meta if the same ver

### DIFF
--- a/src/libaktualizr/uptane/imagerepository.cc
+++ b/src/libaktualizr/uptane/imagerepository.cc
@@ -44,7 +44,7 @@ void ImageRepository::fetchSnapshot(INvStorage& storage, const IMetadataFetcher&
 
   if (local_version > remote_version) {
     throw Uptane::SecurityException(RepositoryType::IMAGE, "Rollback attempt");
-  } else if (local_version < remote_version) {
+  } else {
     storage.storeNonRoot(image_snapshot, RepositoryType::Image(), Role::Snapshot());
   }
 }
@@ -118,7 +118,7 @@ void ImageRepository::fetchTargets(INvStorage& storage, const IMetadataFetcher& 
 
   if (local_version > remote_version) {
     throw Uptane::SecurityException(RepositoryType::IMAGE, "Rollback attempt");
-  } else if (local_version < remote_version) {
+  } else {
     storage.storeNonRoot(image_targets, RepositoryType::Image(), targets_role);
   }
 }
@@ -219,11 +219,15 @@ void ImageRepository::updateMeta(INvStorage& storage, const IMetadataFetcher& fe
       local_version = -1;
     }
 
+    const auto timestamp_stored_signature{timestamp.isInitialized() ? timestamp.signature() : ""};
     verifyTimestamp(image_timestamp);
 
     if (local_version > remote_version) {
       throw Uptane::SecurityException(RepositoryType::IMAGE, "Rollback attempt");
-    } else if (local_version < remote_version) {
+    } else if (local_version < remote_version || timestamp_stored_signature != timestamp.signature()) {
+      // If local and remote versions are the same but their content actually differ then store/update the metadata in
+      // DB We assume that the metadata contains just one signature, otherwise the comparison might not always work
+      // correctly.
       storage.storeNonRoot(image_timestamp, RepositoryType::Image(), Role::Timestamp());
     }
 

--- a/src/libaktualizr/uptane/tuf.cc
+++ b/src/libaktualizr/uptane/tuf.cc
@@ -318,6 +318,27 @@ Uptane::BaseMeta::BaseMeta(RepositoryType repo, const Role &role, const Json::Va
   init(json);
 }
 
+std::string Uptane::BaseMeta::signature() const {
+  if (!original_object_.isMember("signatures")) {
+    throw Uptane::InvalidMetadata("", "", "invalid metadata json, missing signatures");
+  }
+  if (!original_object_["signatures"].isArray()) {
+    throw Uptane::InvalidMetadata("", "", "invalid metadata json, signatures are not an array");
+  }
+  const auto signs{original_object_["signatures"]};
+  if (signs.size() == 0) {
+    throw Uptane::InvalidMetadata("", "", "invalid metadata json, no any signatures found");
+  }
+  if (signs.size() > 1) {
+    LOG_WARNING << "Metadata contains more than one signature\n" << original_object_;
+  }
+  if (!signs[0].isMember("sig")) {
+    throw Uptane::InvalidMetadata("", "", "invalid metadata json, missing signature");
+  }
+
+  return signs[0]["sig"].asString();
+}
+
 void Uptane::Targets::init(const Json::Value &json) {
   if (!json.isObject() || json["signed"]["_type"] != "Targets") {
     throw Uptane::InvalidMetadata("", "targets", "invalid targets.json");

--- a/src/libaktualizr/uptane/tuf.h
+++ b/src/libaktualizr/uptane/tuf.h
@@ -153,7 +153,14 @@ class BaseMeta {
   TimeStamp expiry() const { return expiry_; }
   bool isExpired(const TimeStamp &now) const { return expiry_.IsExpiredAt(now); }
   Json::Value original() const { return original_object_; }
-
+  /**
+   * Get the first signature of a given meta.
+   *
+   * Assumption is that a given metadata includes "signatures" attribute that contains at least one signature.
+   * @return the first found signature or exception is thrown if not found.
+   */
+  std::string signature() const;
+  bool isInitialized() const { return !original_object_.isNull(); }
   bool operator==(const BaseMeta &rhs) const { return version_ == rhs.version() && expiry_ == rhs.expiry(); }
 
  protected:

--- a/src/uptane_generator/repo.cc
+++ b/src/uptane_generator/repo.cc
@@ -39,6 +39,9 @@ void Repo::addDelegationToSnapshot(Json::Value *snapshot, const Uptane::Role &ro
   std::string signed_role = Utils::readFile(repo_dir / role_file_name);
 
   (*snapshot)["meta"][role_file_name]["version"] = role_json["version"].asUInt();
+  (*snapshot)["meta"][role_file_name]["length"] = signed_role.size();
+  (*snapshot)["meta"][role_file_name]["hashes"]["sha256"] =
+      boost::algorithm::to_lower_copy(boost::algorithm::hex(Crypto::sha256digest(signed_role)));
 
   if (role_json["delegations"].isObject()) {
     auto delegations_list = role_json["delegations"]["roles"];


### PR DESCRIPTION
Allow updating metadata if local and remote versions are the same but
they actually differ.

Signed-off-by: Mike Sul <mike.sul@foundries.io>