### PR TITLE
Improve update event sending

### DIFF
--- a/src/libaktualizr/primary/reportqueue.h
+++ b/src/libaktualizr/primary/reportqueue.h
@@ -109,6 +109,7 @@ class ReportQueue {
   std::shared_ptr<INvStorage> storage;
   const int run_pause_s_;
   const int event_number_limit_;
+  int cur_event_number_limit_;
 };
 
 #endif  // REPORTQUEUE_H_

--- a/src/libaktualizr/primary/reportqueue.h
+++ b/src/libaktualizr/primary/reportqueue.h
@@ -87,7 +87,7 @@ class EcuInstallationCompletedReport : public ReportEvent {
 class ReportQueue {
  public:
   ReportQueue(const Config& config_in, std::shared_ptr<HttpInterface> http_client,
-              std::shared_ptr<INvStorage> storage_in);
+              std::shared_ptr<INvStorage> storage_in, int run_pause_s = 10, int event_number_limit = -1);
   ~ReportQueue();
   ReportQueue(const ReportQueue&) = delete;
   ReportQueue(ReportQueue&&) = delete;
@@ -107,6 +107,8 @@ class ReportQueue {
   std::queue<std::unique_ptr<ReportEvent>> report_queue_;
   bool shutdown_{false};
   std::shared_ptr<INvStorage> storage;
+  const int run_pause_s_;
+  const int event_number_limit_;
 };
 
 #endif  // REPORTQUEUE_H_

--- a/src/libaktualizr/storage/invstorage.h
+++ b/src/libaktualizr/storage/invstorage.h
@@ -137,7 +137,7 @@ class INvStorage {
   virtual bool loadEcuReportCounter(std::vector<std::pair<Uptane::EcuSerial, int64_t>>* results) const = 0;
 
   virtual void saveReportEvent(const Json::Value& json_value) = 0;
-  virtual bool loadReportEvents(Json::Value* report_array, int64_t* id_max) const = 0;
+  virtual bool loadReportEvents(Json::Value* report_array, int64_t* id_max, int limit = -1) const = 0;
   virtual void deleteReportEvents(int64_t id_max) = 0;
 
   virtual void storeDeviceDataHash(const std::string& data_type, const std::string& hash) = 0;

--- a/src/libaktualizr/storage/sqlstorage.cc
+++ b/src/libaktualizr/storage/sqlstorage.cc
@@ -1571,9 +1571,9 @@ void SQLStorage::saveReportEvent(const Json::Value& json_value) {
   }
 }
 
-bool SQLStorage::loadReportEvents(Json::Value* report_array, int64_t* id_max) const {
+bool SQLStorage::loadReportEvents(Json::Value* report_array, int64_t* id_max, int limit) const {
   SQLite3Guard db = dbConnection();
-  auto statement = db.prepareStatement("SELECT id, json_string FROM report_events;");
+  auto statement = db.prepareStatement<int>("SELECT id, json_string FROM report_events LIMIT ?;", limit);
   int statement_result = statement.step();
   if (statement_result != SQLITE_DONE && statement_result != SQLITE_ROW) {
     LOG_ERROR << "Failed to get report events: " << db.errmsg();

--- a/src/libaktualizr/storage/sqlstorage.h
+++ b/src/libaktualizr/storage/sqlstorage.h
@@ -97,7 +97,7 @@ class SQLStorage : public SQLStorageBase, public INvStorage {
   void saveEcuReportCounter(const Uptane::EcuSerial& ecu_serial, int64_t counter) override;
   bool loadEcuReportCounter(std::vector<std::pair<Uptane::EcuSerial, int64_t>>* results) const override;
   void saveReportEvent(const Json::Value& json_value) override;
-  bool loadReportEvents(Json::Value* report_array, int64_t* id_max) const override;
+  bool loadReportEvents(Json::Value* report_array, int64_t* id_max, int limit = -1) const override;
   void deleteReportEvents(int64_t id_max) override;
   void clearInstallationResults() override;
 

--- a/src/libaktualizr/storage/sqlstorage_test.cc
+++ b/src/libaktualizr/storage/sqlstorage_test.cc
@@ -516,6 +516,33 @@ TEST(sqlstorage, migrate_from_fs) {
   }
 }
 
+TEST(sqlstorage, store_and_load_report_events) {
+  TemporaryDirectory temp_dir;
+  StorageConfig config;
+  config.path = temp_dir.Path();
+  auto storage = INvStorage::newStorage(config);
+
+  const int event_numb{10};
+  for (int ii = 0; ii < event_numb; ++ii) {
+    storage->saveReportEvent(Utils::parseJSON(R"("id": "some ID", "eventType": "some Event")"));
+  }
+  int64_t max_id;
+  {
+    Json::Value events{Json::arrayValue};
+    storage->loadReportEvents(&events, &max_id);
+    EXPECT_EQ(events.size(), event_numb);
+  }
+  const std::vector<int> event_number_limits{1, 4, 3, 5};
+  int processed_events{0};
+  for (const auto& l : event_number_limits) {
+    Json::Value events{Json::arrayValue};
+    storage->loadReportEvents(&events, &max_id, l);
+    EXPECT_EQ(events.size(), l < (event_numb - processed_events) ? l : event_numb - processed_events);
+    storage->deleteReportEvents(max_id);
+    processed_events += l;
+  }
+}
+
 #ifndef __NO_MAIN__
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
- Add ability to limit a number of events to include into a single request to Device Gateway.
- Handle 413 response to HTTP POST /events request by re-trying with
  fewer events in a body until just one event is sent.
- If 413 to a request that carries just one event then just drop the event and stop trying to send it.
- Add unit tests for the aforementioned functionality.