### PR TITLE
[fio extras] Adjust test_config after fio changes

### DIFF
--- a/src/libaktualizr/config/config_test.cc
+++ b/src/libaktualizr/config/config_test.cc
@@ -19,7 +19,7 @@ boost::filesystem::path build_dir;
 TEST(config, DefaultValues) {
   Config conf;
   EXPECT_EQ(conf.uptane.key_type, KeyType::kRSA2048);
-  EXPECT_EQ(conf.uptane.polling_sec, 10u);
+  EXPECT_EQ(conf.uptane.polling_sec, 300u);
 }
 
 TEST(config, TomlBasic) {
@@ -31,7 +31,7 @@ TEST(config, TomlEmpty) {
   Config conf;
   conf.updateFromTomlString("");
   EXPECT_EQ(conf.uptane.key_type, KeyType::kRSA2048);
-  EXPECT_EQ(conf.uptane.polling_sec, 10u);
+  EXPECT_EQ(conf.uptane.polling_sec, 300u);
 }
 
 TEST(config, TomlInt) {


### PR DESCRIPTION
Commit 9b8a74d9 ([fio extras] Update default config values, 2020-09-18) adjusted default polling_sec from 10 to 300. This commit makes test_config unit test pass again by adjusting the expected values.