### PR TITLE
[fio extras] Reduce severity of log messages during an update

### DIFF
--- a/src/libaktualizr/uptane/imagerepository.cc
+++ b/src/libaktualizr/uptane/imagerepository.cc
@@ -174,7 +174,7 @@ void ImageRepository::verifyTargets(const std::string& targets_raw, bool prefetc
       throw Uptane::VersionMismatch(RepositoryType::IMAGE, Uptane::Role::TARGETS);
     }
   } catch (const Exception& e) {
-    LOG_ERROR << "Signature verification for Image repo Targets metadata failed";
+    LOG_INFO << "Signature verification for Image repo Targets metadata failed";
     throw;
   }
 }
@@ -190,7 +190,7 @@ std::shared_ptr<Uptane::Targets> ImageRepository::verifyDelegation(const std::st
     auto signer = std::make_shared<MetaWithKeys>(parent_target);
     return std::make_shared<Uptane::Targets>(Targets(RepositoryType::Image(), role, delegation_json, signer));
   } catch (const Exception& e) {
-    LOG_ERROR << "Signature verification for Image repo delegated Targets metadata failed";
+    LOG_INFO << "Signature verification for Image repo delegated Targets metadata failed";
     throw;
   }
 
@@ -254,7 +254,7 @@ void ImageRepository::updateMeta(INvStorage& storage, const IMetadataFetcher& fe
         fetch_snapshot = false;
         LOG_DEBUG << "Skipping Image repo Snapshot download; stored version is still current.";
       } catch (const Uptane::Exception& e) {
-        LOG_ERROR << "Image repo Snapshot verification failed: " << e.what();
+        LOG_INFO << "Image repo Snapshot verification failed: " << e.what();
       }
       local_version = snapshot.version();
     } else {
@@ -282,7 +282,7 @@ void ImageRepository::updateMeta(INvStorage& storage, const IMetadataFetcher& fe
         fetch_targets = false;
         LOG_DEBUG << "Skipping Image repo Targets download; stored version is still current.";
       } catch (const std::exception& e) {
-        LOG_ERROR << "Image repo Target verification failed: " << e.what();
+        LOG_INFO << "Image repo Target verification failed: " << e.what();
       }
       if (targets) {
         local_version = targets->version();


### PR DESCRIPTION
Regular messages were being shown as errors, potentially leading users to believe that something was wrong even during normal operation.

Before:
```
   info: Checking for a new Target...
  error: Image repo Snapshot verification failed: Snapshot metadata hash verification failed
  error: Signature verification for Image repo Targets metadata failed
  error: Image repo Target verification failed: Hash metadata mismatch
   info: Found new and valid Target to update to: intel-corei7-64-lmp-5, sha256: 0a0ce20ab014cb318706c6f104c180750528e0baad2a43d0a69ee1b774e7dc52
```
After:
```
   info: Checking for a new Target...
   info: Image repo Snapshot verification failed: Snapshot metadata hash verification failed
   info: Signature verification for Image repo Targets metadata failed
   info: Image repo Target verification failed: Hash metadata mismatch
   info: Found new and valid Target to update to: intel-corei7-64-lmp-7, sha256: 0a0ce20ab014cb318706c6f104c180750528e0baad2a43d0a69ee1b774e7dc52
```
Errors are usually highlighted in red during execution.
