### PR TITLE
libaktualizr-posix: asn1-cer.h needs cstdint

### DIFF
--- a/src/libaktualizr-posix/asn1/asn1-cer.h
+++ b/src/libaktualizr-posix/asn1/asn1-cer.h
@@ -3,6 +3,7 @@
 
 #include <stdexcept>
 #include <string>
+#include <cstdint>
 
 // Limitations:
 //   - Maximal supported integer width of 32 bits


### PR DESCRIPTION
fix build with gcc
```
| /srv/oe/build/tmp-lmp/work/cortexa57-lmp-linux/aktualizr/1.0+gitAUTOINC+257511849d-7/git/aktualizr/src/libaktualizr-posix/asn1/asn1-cer.h:56:1: error: 'uint8_t' does not name a type
|    56 | uint8_t cer_decode_token(const std::string& ber, int32_t* endpos, int32_t* int_param, std::string* string_param);
|       | ^~~~~~~
| /srv/oe/build/tmp-lmp/work/cortexa57-lmp-linux/aktualizr/1.0+gitAUTOINC+257511849d-7/git/aktualizr/src/libaktualizr-posix/asn1/asn1-cer.h:5:1: note: 'uint8_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
```