### PR TITLE
[fio extras] Reduce severity of log messages during an update (v2)

### DIFF
--- a/src/libaktualizr/uptane/imagerepository.h
+++ b/src/libaktualizr/uptane/imagerepository.h
@@ -16,7 +16,7 @@ class ImageRepository : public RepositoryCommon {
 
   void resetMeta();
 
-  void verifyTargets(const std::string& targets_raw, bool prefetch);
+  void verifyTargets(const std::string& targets_raw, bool prefetch, bool hash_change_expected);
 
   void verifyTimestamp(const std::string& timestamp_raw);
 


### PR DESCRIPTION
This commit differentiates, based on the client state, the severity of some log messages shown when the content of snapshot or targets metadata files do not match the expected hash. During a typical update, when the hash verification is expected to fail, the messages are logged as info. Otherwise, they are logged as errors, keeping the current behavior.

If the overall solution seems OK, there are two things that could be discussed:
- `static int last_snapshot_version_in_timestamp = -1;` this prioritizes `LOG_INFO` over `LOG_ERROR` if there is a hash mismatch on the first execution of `updateMeta`. We could alternatively parse the current local timestamp to get the expected snapshot version from the previous execution, but it seems to me that it is not worth it. Prioritizing `LOG_ERROR` over `LOG_INFO` would be easy, if that's better.
- Repeating the same message string in the code for 2 or 3 times is not elegant, but adding additional logic to prevent repetition that may be even worse. 
