### PR TITLE
Fix mechanism that controls if new timestamp should be stored + add test

### DIFF
--- a/src/libaktualizr/primary/aktualizr_lite_test.cc
+++ b/src/libaktualizr/primary/aktualizr_lite_test.cc
@@ -288,6 +288,34 @@ TEST_F(AkliteTest, ostreeUpdate) {
   }
 }
 
+/*
+ * Test that verifies if metadata files are being stored when there are changes and also not being stored
+ * when the files have not changed.
+ */
+TEST_F(AkliteTest, timestampStoreLogsTest) {
+  AkliteMock aklite{conf()};
+  std::string log_output;
+  tufRepo().add_target("target-01", treehub().getRev(), "primary_hw");
+
+  // On first update, metadata is expected to be stored
+  testing::internal::CaptureStdout();
+  logger_set_threshold(boost::log::trivial::debug);
+  aklite.update();
+  log_output = testing::internal::GetCapturedStdout();
+  EXPECT_NE(std::string::npos, log_output.find("Storing timestamp for image repo"));
+  EXPECT_NE(std::string::npos, log_output.find("Storing snapshot for image repo"));
+  EXPECT_NE(std::string::npos, log_output.find("Storing targets for image repo"));
+
+  // If there were no changes, no metadata should be stored
+  testing::internal::CaptureStdout();
+  logger_set_threshold(boost::log::trivial::debug);
+  aklite.update();
+  log_output = testing::internal::GetCapturedStdout();
+  EXPECT_EQ(std::string::npos, log_output.find("Storing timestamp for image repo"));
+  EXPECT_EQ(std::string::npos, log_output.find("Storing snapshot for image repo"));
+  EXPECT_EQ(std::string::npos, log_output.find("Storing targets for image repo"));
+}
+
 #ifndef __NO_MAIN__
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);

--- a/src/libaktualizr/storage/sqlstorage.cc
+++ b/src/libaktualizr/storage/sqlstorage.cc
@@ -535,6 +535,7 @@ void SQLStorage::storeRoot(const std::string& data, Uptane::RepositoryType repo,
 void SQLStorage::storeNonRoot(const std::string& data, Uptane::RepositoryType repo, const Uptane::Role role) {
   SQLite3Guard db = dbConnection();
 
+  LOG_DEBUG << "Storing " << role << " for " << repo << " repo in SQL storage";
   db.beginTransaction();
 
   auto del_statement = db.prepareStatement<int, int>("DELETE FROM meta WHERE (repo=? AND meta_type=?);",

--- a/src/libaktualizr/uptane/imagerepository.cc
+++ b/src/libaktualizr/uptane/imagerepository.cc
@@ -209,6 +209,8 @@ void ImageRepository::updateRoot(INvStorage& storage, const IMetadataFetcher& fe
 }
 
 void ImageRepository::updateMeta(INvStorage& storage, const IMetadataFetcher& fetcher) {
+  const auto timestamp_stored_signature{timestamp.isInitialized() ? timestamp.signature() : ""};
+
   updateRoot(storage, fetcher);
 
   // Update Image repo Timestamp metadata
@@ -226,7 +228,6 @@ void ImageRepository::updateMeta(INvStorage& storage, const IMetadataFetcher& fe
       local_version = -1;
     }
 
-    const auto timestamp_stored_signature{timestamp.isInitialized() ? timestamp.signature() : ""};
     verifyTimestamp(image_timestamp);
 
     if (local_version > remote_version) {


### PR DESCRIPTION
Previous timestamp signature was never being actually compared to the new one, because the timestamp object was 
accessed after being reset. This caused the timestamp metadata to be stored on every `updateMeta` call, instead of only on changes.

Added an unit test in a second commit. It fails if the first commit is not applied. Not sure if we want to rely that much on debug output messages during testing, but it was the most convenient way to verify the fix. Also, I believe it is convenient to have a debug message on the store metadata.
