### PR TITLE
[fio extras] Enable TLS connections sharing

### DIFF
--- a/src/libaktualizr/http/httpclient.cc
+++ b/src/libaktualizr/http/httpclient.cc
@@ -167,7 +167,7 @@ void HttpClient::setCerts(const std::string& ca, CryptoSource ca_source, const s
 }
 
 HttpResponse HttpClient::get(const std::string& url, int64_t maxsize) {
-  CURL* curl_get = Utils::curlDupHandleWrapper(curl, pkcs11_key);
+  CURL* curl_get = dupHandle(curl, pkcs11_key);
 
   curlEasySetoptWrapper(curl_get, CURLOPT_HTTPHEADER, headers);
 
@@ -187,7 +187,7 @@ HttpResponse HttpClient::get(const std::string& url, int64_t maxsize) {
 }
 
 HttpResponse HttpClient::post(const std::string& url, const std::string& content_type, const std::string& data) {
-  CURL* curl_post = Utils::curlDupHandleWrapper(curl, pkcs11_key);
+  CURL* curl_post = dupHandle(curl, pkcs11_key);
   curl_slist* req_headers = curl_slist_dup(headers);
   req_headers = curl_slist_append(req_headers, (std::string("Content-Type: ") + content_type).c_str());
   curlEasySetoptWrapper(curl_post, CURLOPT_HTTPHEADER, req_headers);
@@ -207,7 +207,7 @@ HttpResponse HttpClient::post(const std::string& url, const Json::Value& data) {
 }
 
 HttpResponse HttpClient::put(const std::string& url, const std::string& content_type, const std::string& data) {
-  CURL* curl_put = Utils::curlDupHandleWrapper(curl, pkcs11_key);
+  CURL* curl_put = dupHandle(curl, pkcs11_key);
   curl_slist* req_headers = curl_slist_dup(headers);
   req_headers = curl_slist_append(req_headers, (std::string("Content-Type: ") + content_type).c_str());
   curlEasySetoptWrapper(curl_put, CURLOPT_HTTPHEADER, req_headers);
@@ -273,7 +273,7 @@ HttpResponse HttpClient::download(const std::string& url, curl_write_callback wr
 std::future<HttpResponse> HttpClient::downloadAsync(const std::string& url, curl_write_callback write_cb,
                                                     curl_xferinfo_callback progress_cb, void* userp, curl_off_t from,
                                                     CurlHandler* easyp) {
-  CURL* curl_download = Utils::curlDupHandleWrapper(curl, pkcs11_key);
+  CURL* curl_download = dupHandle(curl, pkcs11_key);
 
   CurlHandler curlp = CurlHandler(curl_download, curl_easy_cleanup);
 
@@ -352,4 +352,42 @@ curl_slist* HttpClient::curl_slist_dup(curl_slist* sl) {
   return new_list;
 }
 
+/* Locking for curl share instance */
+static void curl_share_lock_cb(CURL* handle, curl_lock_data data, curl_lock_access access, void* userptr) {
+  (void)handle;
+  (void)access;
+  auto* mutexes = static_cast<std::array<std::mutex, CURL_LOCK_DATA_LAST>*>(userptr);
+  mutexes->at(data).lock();
+}
+
+static void curl_share_unlock_cb(CURL* handle, curl_lock_data data, void* userptr) {
+  (void)handle;
+  auto* mutexes = static_cast<std::array<std::mutex, CURL_LOCK_DATA_LAST>*>(userptr);
+  mutexes->at(data).unlock();
+}
+
+void HttpClientWithShare::initCurlShare() {
+  share_ = curl_share_init();
+  if (share_ == nullptr) {
+    throw std::runtime_error("Could not initialize share");
+  }
+
+  curl_share_setopt(share_, CURLSHOPT_SHARE, CURL_LOCK_DATA_SSL_SESSION);
+  curl_share_setopt(share_, CURLSHOPT_SHARE, CURL_LOCK_DATA_DNS);
+  curl_share_setopt(share_, CURLSHOPT_SHARE, CURL_LOCK_DATA_CONNECT);
+  curl_share_setopt(share_, CURLSHOPT_LOCKFUNC, curl_share_lock_cb);
+  curl_share_setopt(share_, CURLSHOPT_UNLOCKFUNC, curl_share_unlock_cb);
+  curl_share_setopt(share_, CURLSHOPT_USERDATA, &curl_share_mutexes);
+}
+
+HttpClientWithShare::HttpClientWithShare(const std::vector<std::string>* extra_headers,
+                                         const std::set<std::string>* response_header_names)
+    : HttpClient(extra_headers, response_header_names) {
+  initCurlShare();
+}
+HttpClientWithShare::HttpClientWithShare(const std::string& socket) : HttpClient(socket) { initCurlShare(); }
+
+HttpClientWithShare::HttpClientWithShare(const HttpClientWithShare& curl_in) : HttpClient(curl_in) { initCurlShare(); }
+
+HttpClientWithShare::~HttpClientWithShare() { curl_share_cleanup(share_); }
 // vim: set tabstop=2 shiftwidth=2 expandtab:

--- a/src/libaktualizr/http/httpclient.h
+++ b/src/libaktualizr/http/httpclient.h
@@ -58,6 +58,9 @@ class HttpClient : public HttpInterface {
   curl_slist *headers;
   HttpResponse perform(CURL *curl_handler, int retry_times, int64_t size_limit);
   static curl_slist *curl_slist_dup(curl_slist *sl);
+  virtual CURL *dupHandle(CURL *const curl_in, const bool using_pkcs11) {
+    return Utils::curlDupHandleWrapper(curl_in, using_pkcs11, nullptr);
+  }
 
   std::unique_ptr<TemporaryFile> tls_ca_file;
   std::unique_ptr<TemporaryFile> tls_cert_file;
@@ -76,4 +79,27 @@ class HttpClient : public HttpInterface {
   bool pkcs11_cert{false};
   std::set<std::string> response_header_names_;
 };
+
+class HttpClientWithShare : public HttpClient {
+ public:
+  explicit HttpClientWithShare(const std::vector<std::string> *extra_headers = nullptr,
+                               const std::set<std::string> *response_header_names = nullptr);
+  explicit HttpClientWithShare(const std::string &socket);
+  HttpClientWithShare(const HttpClientWithShare &curl_in);  // non-default!
+  ~HttpClientWithShare() override;
+  HttpClientWithShare(HttpClientWithShare &&) = delete;
+  HttpClientWithShare &operator=(const HttpClientWithShare &) = delete;
+  HttpClientWithShare &operator=(HttpClientWithShare &&) = delete;
+
+ protected:
+  CURL *dupHandle(CURL *const curl_in, const bool using_pkcs11) override {
+    return Utils::curlDupHandleWrapper(curl_in, using_pkcs11, share_);
+  }
+  void initCurlShare();
+
+ private:
+  CURLSH *share_{nullptr};
+  std::array<std::mutex, CURL_LOCK_DATA_LAST> curl_share_mutexes;
+};
+
 #endif

--- a/src/libaktualizr/utilities/utils.cc
+++ b/src/libaktualizr/utilities/utils.cc
@@ -814,7 +814,7 @@ std::string Utils::urlEncode(const std::string &input) {
   return res;
 }
 
-CURL *Utils::curlDupHandleWrapper(CURL *const curl_in, const bool using_pkcs11) {
+CURL *Utils::curlDupHandleWrapper(CURL *const curl_in, const bool using_pkcs11, CURLSH *share) {
   CURL *curl = curl_easy_duphandle(curl_in);
 
   // This is a workaround for a bug in curl. It has been fixed in
@@ -823,6 +823,9 @@ CURL *Utils::curlDupHandleWrapper(CURL *const curl_in, const bool using_pkcs11) 
   // workaround.
   if (using_pkcs11) {
     curlEasySetoptWrapper(curl, CURLOPT_SSLENGINE, "pkcs11");
+  }
+  if (share != nullptr) {
+    curl_easy_setopt(curl, CURLOPT_SHARE, share);
   }
   return curl;
 }

--- a/src/libaktualizr/utilities/utils.h
+++ b/src/libaktualizr/utilities/utils.h
@@ -44,7 +44,7 @@ struct Utils {
   static void createDirectories(const boost::filesystem::path &path, mode_t mode);
   static bool createSecureDirectory(const boost::filesystem::path &path);
   static std::string urlEncode(const std::string &input);
-  static CURL *curlDupHandleWrapper(CURL *curl_in, bool using_pkcs11);
+  static CURL *curlDupHandleWrapper(CURL *curl_in, bool using_pkcs11, CURLSH *share);
   static std::vector<boost::filesystem::path> getDirEntriesByExt(const boost::filesystem::path &dir_path,
                                                                  const std::string &ext);
   static void setStorageRootPath(const std::string &storage_root_path);


### PR DESCRIPTION
This commit enables sharing of TLS connections among sequential HTTP requests, speeding up operations and saving network resources. It does not enable sharing for data download operations, since multiple download operations might happen in parallel.

---

I'm assuming that a single HttpClient instance will **not** have put/get/post calls being done from separate threads, potentially in parallel. If we can't guarantee that, a locking mechanism must be added.

### Ad-hoc analysis of network traffic before and after the change ###

Traffic between starting aktualizr-lite and the `info: Device is up-to-date`  message:
- Before: 51410 bytes
- After: 32567 bytes

Single TUF polling (reusing connections from last poll):
- Before: 15941 bytes
- After: 3688 bytes

The time it takes until execution reaches the `info: Device is up-to-date` message is also reduced considerably.
