### PR TITLE
[fio toup] http: Set upload data size explicitly

### DIFF
--- a/src/libaktualizr/http/httpclient.cc
+++ b/src/libaktualizr/http/httpclient.cc
@@ -194,6 +194,7 @@ HttpResponse HttpClient::post(const std::string& url, const std::string& content
   curlEasySetoptWrapper(curl_post, CURLOPT_URL, url.c_str());
   curlEasySetoptWrapper(curl_post, CURLOPT_POST, 1);
   curlEasySetoptWrapper(curl_post, CURLOPT_POSTFIELDS, data.c_str());
+  curlEasySetoptWrapper(curl_post, CURLOPT_POSTFIELDSIZE, data.size());
   auto result = perform(curl_post, RETRY_TIMES, HttpInterface::kPostRespLimit);
   curl_easy_cleanup(curl_post);
   curl_slist_free_all(req_headers);


### PR DESCRIPTION
This change instructs `curl` to set the content length header properly if a binary data are posted. By default, `libcurl` calculates the body size by utilizing `strlen()` call, which obviously doesn't work for binary data.
Specifically, it's required for a correct image posting to the docker daemon (`HTTP POST /images/load`) that implies uploading of a TAR stream/data.