### PR TITLE
[fio extra] Expose keys of the generated repo

### DIFF
--- a/src/uptane_generator/repo.h
+++ b/src/uptane_generator/repo.h
@@ -43,6 +43,7 @@ class Repo {
   void generateCampaigns() const;
   void refresh(const Uptane::Role &role);
   void rotate(const Uptane::Role &role, KeyType key_type = KeyType::kRSA2048);
+  KeyPair getKey(const Uptane::Role &role) const { return keys_.at(role); }
 
  protected:
   void generateRepoKeys(KeyType key_type);


### PR DESCRIPTION
Add method to get role keys of the TUF image repo. This is the functionality that is used for unit tests mainly.