### PR TITLE
[fio toup] reportqueue: Do not wake up periodically on empty queue

### DIFF
--- a/src/libaktualizr/primary/reportqueue.h
+++ b/src/libaktualizr/primary/reportqueue.h
@@ -108,6 +108,7 @@ class ReportQueue {
   std::queue<std::unique_ptr<ReportEvent>> report_queue_;
   bool shutdown_{false};
   bool is_online_{false};
+  bool no_pending_events_{false};
   std::shared_ptr<INvStorage> storage;
   const int run_pause_s_;
   const int event_number_limit_;


### PR DESCRIPTION
If there are no events to be sent, there is no reason to wake up periodically to try to send pending events. In this case, we should only resume execution once a new event is generated, and the thread is notified.