### PR TITLE
[fio extras] storage: allow target to be marked as bad

### DIFF
--- a/src/libaktualizr/storage/invstorage.h
+++ b/src/libaktualizr/storage/invstorage.h
@@ -36,7 +36,7 @@ struct MisconfiguredEcu {
   EcuState state;
 };
 
-enum class InstalledVersionUpdateMode { kNone, kCurrent, kPending };
+enum class InstalledVersionUpdateMode { kNone, kCurrent, kPending, kBadTarget };
 
 // Functions loading/storing multiple pieces of data are supposed to do so
 // atomically as far as implementation makes it possible.

--- a/src/libaktualizr/storage/invstorage.h
+++ b/src/libaktualizr/storage/invstorage.h
@@ -116,8 +116,8 @@ class INvStorage {
                                     InstalledVersionUpdateMode update_mode) = 0;
   virtual bool loadInstalledVersions(const std::string& ecu_serial, boost::optional<Uptane::Target>* current_version,
                                      boost::optional<Uptane::Target>* pending_version) const = 0;
-  virtual bool loadInstallationLog(const std::string& ecu_serial, std::vector<Uptane::Target>* log,
-                                   bool only_installed) const = 0;
+  virtual bool loadInstallationLog(const std::string& ecu_serial, std::vector<Uptane::Target>* log, bool only_installed,
+                                   bool include_current = true) const = 0;
   virtual bool hasPendingInstall() = 0;
   virtual void getPendingEcus(std::vector<std::pair<Uptane::EcuSerial, Hash>>* pendingEcus) = 0;
   virtual void clearInstalledVersions() = 0;
@@ -166,8 +166,9 @@ class INvStorage {
   void savePrimaryInstalledVersion(const Uptane::Target& target, InstalledVersionUpdateMode update_mode) {
     return saveInstalledVersion("", target, update_mode);
   }
-  bool loadPrimaryInstallationLog(std::vector<Uptane::Target>* log, bool only_installed) const {
-    return loadInstallationLog("", log, only_installed);
+  bool loadPrimaryInstallationLog(std::vector<Uptane::Target>* log, bool only_installed,
+                                  bool include_current = true) const {
+    return loadInstallationLog("", log, only_installed, include_current);
   }
   void importInstalledVersions(const boost::filesystem::path& base_path);
 

--- a/src/libaktualizr/storage/sqlstorage.cc
+++ b/src/libaktualizr/storage/sqlstorage.cc
@@ -1193,7 +1193,7 @@ static void loadEcuMap(SQLite3Guard& db, std::string& ecu_serial, Uptane::EcuMap
 }
 
 bool SQLStorage::loadInstallationLog(const std::string& ecu_serial, std::vector<Uptane::Target>* log,
-                                     bool only_installed) const {
+                                     bool only_installed, bool include_current) const {
   SQLite3Guard db = dbConnection();
 
   std::string ecu_serial_real = ecu_serial;
@@ -1201,12 +1201,13 @@ bool SQLStorage::loadInstallationLog(const std::string& ecu_serial, std::vector<
   loadEcuMap(db, ecu_serial_real, ecu_map);
 
   std::string query =
-      "SELECT id, sha256, name, hashes, length, correlation_id, custom_meta FROM installed_versions WHERE "
-      "ecu_serial = ? ORDER BY id;";
+      std::string(
+          "SELECT id, sha256, name, hashes, length, correlation_id, custom_meta FROM installed_versions WHERE ") +
+      (include_current ? "" : " is_current = 0 AND ") + "ecu_serial = ? ORDER BY id;";
   if (only_installed) {
-    query =
-        "SELECT id, sha256, name, hashes, length, correlation_id, custom_meta FROM installed_versions WHERE "
-        "ecu_serial = ? AND was_installed = 1 ORDER BY id;";
+    query = std::string(
+                "SELECT id, sha256, name, hashes, length, correlation_id, custom_meta FROM installed_versions WHERE ") +
+            (include_current ? "" : " is_current = 0 AND ") + "ecu_serial = ? AND was_installed = 1 ORDER BY id;";
   }
 
   auto statement = db.prepareStatement<std::string>(query, ecu_serial_real);

--- a/src/libaktualizr/storage/sqlstorage.cc
+++ b/src/libaktualizr/storage/sqlstorage.cc
@@ -1121,16 +1121,29 @@ void SQLStorage::saveInstalledVersion(const std::string& ecu_serial, const Uptan
   }
 
   if (!!old_id) {
-    auto statement = db.prepareStatement<std::string, int, int, int64_t>(
-        "UPDATE installed_versions SET correlation_id = ?, is_current = ?, is_pending = ?, was_installed = ? WHERE id "
-        "= ?;",
-        target.correlation_id(), static_cast<int>(update_mode == InstalledVersionUpdateMode::kCurrent),
-        static_cast<int>(update_mode == InstalledVersionUpdateMode::kPending),
-        static_cast<int>(update_mode == InstalledVersionUpdateMode::kCurrent || old_was_installed), old_id.value());
+    if (update_mode == InstalledVersionUpdateMode::kBadTarget) {
+      // unset 'pending' and 'was_installed' for all installations of the target in the current ecu
+      auto statement = db.prepareStatement<std::string, std::string>(
+          "UPDATE installed_versions SET is_pending = 0, was_installed = 0 WHERE ecu_serial = ? AND name = ?",
+          ecu_serial_real, target.filename());
 
-    if (statement.step() != SQLITE_DONE) {
-      LOG_ERROR << "Failed to save installed versions: " << db.errmsg();
-      return;
+      if (statement.step() != SQLITE_DONE) {
+        LOG_ERROR << "Failed to save installed versions: " << db.errmsg();
+        return;
+      }
+    } else {
+      auto statement = db.prepareStatement<std::string, int, int, int64_t>(
+          "UPDATE installed_versions SET correlation_id = ?, is_current = ?, is_pending = ?, was_installed = ? WHERE "
+          "id "
+          "= ?;",
+          target.correlation_id(), static_cast<int>(update_mode == InstalledVersionUpdateMode::kCurrent),
+          static_cast<int>(update_mode == InstalledVersionUpdateMode::kPending),
+          static_cast<int>(update_mode == InstalledVersionUpdateMode::kCurrent || old_was_installed), old_id.value());
+
+      if (statement.step() != SQLITE_DONE) {
+        LOG_ERROR << "Failed to save installed versions: " << db.errmsg();
+        return;
+      }
     }
   } else {
     std::string custom = Utils::jsonToCanonicalStr(target.custom_data());

--- a/src/libaktualizr/storage/sqlstorage.h
+++ b/src/libaktualizr/storage/sqlstorage.h
@@ -80,8 +80,8 @@ class SQLStorage : public SQLStorageBase, public INvStorage {
                             InstalledVersionUpdateMode update_mode) override;
   bool loadInstalledVersions(const std::string& ecu_serial, boost::optional<Uptane::Target>* current_version,
                              boost::optional<Uptane::Target>* pending_version) const override;
-  bool loadInstallationLog(const std::string& ecu_serial, std::vector<Uptane::Target>* log,
-                           bool only_installed) const override;
+  bool loadInstallationLog(const std::string& ecu_serial, std::vector<Uptane::Target>* log, bool only_installed,
+                           bool include_current = true) const override;
   bool hasPendingInstall() override;
   void getPendingEcus(std::vector<std::pair<Uptane::EcuSerial, Hash>>* pendingEcus) override;
   void clearInstalledVersions() override;


### PR DESCRIPTION
This feature is required to allow a rollback operation to be forced on a target whose installation was finished.