### PR TITLE
Improve current target detection in staged mode

### DIFF
--- a/src/libaktualizr/package_manager/ostreemanager.cc
+++ b/src/libaktualizr/package_manager/ostreemanager.cc
@@ -293,6 +293,25 @@ OstreeManager::OstreeManager(const PackageConfig &pconfig, const BootloaderConfi
   if (imageUpdated()) {
     bootloader_->setBootOK();
   }
+
+  if (pconfig.booted == BootedType::kStaged) {
+    auto ostree_hash_file = bconfig.reboot_sentinel_dir / "staged_booted_ostree_hash";
+    bool reboot_needed;
+    storage_->loadNeedReboot(&reboot_needed);
+    bool reboot_pending = reboot_needed && !bootloader_->rebootDetected();
+    if (!reboot_pending) {
+      // If there is no reboot pending, assume the system is running the latest sysroot deployment
+      bootedStagedOstreeHash = getCurrentHash();
+      Utils::writeFile(ostree_hash_file, bootedStagedOstreeHash, false);
+      LOG_DEBUG << "OstreeManager: Saving ostree hash " << bootedStagedOstreeHash;
+    } else {
+      // If there a reboot pending, use the latest hash recorded when there was no reboot pending
+      if (boost::filesystem::exists(ostree_hash_file)) {
+        bootedStagedOstreeHash = Utils::readFile(ostree_hash_file, true);
+        LOG_DEBUG << "OstreeManager: Reading ostree hash " << bootedStagedOstreeHash;
+      }
+    }
+  }
 }
 
 OstreeManager::~OstreeManager() { bootloader_.reset(nullptr); }
@@ -389,7 +408,13 @@ std::string OstreeManager::getCurrentHash() const {
 }
 
 Uptane::Target OstreeManager::getCurrent() const {
-  const std::string current_hash = getCurrentHash();
+  std::string current_hash;
+  if (config.booted == BootedType::kStaged && !bootedStagedOstreeHash.empty()) {
+    current_hash = bootedStagedOstreeHash;
+  } else {
+    current_hash = getCurrentHash();
+  }
+
   boost::optional<Uptane::Target> current_version;
   // This may appear Primary-specific, but since Secondaries only know about
   // themselves, this actually works just fine for them, too.

--- a/src/libaktualizr/package_manager/ostreemanager.h
+++ b/src/libaktualizr/package_manager/ostreemanager.h
@@ -78,6 +78,7 @@ class OstreeManager : public PackageManagerInterface {
   TargetStatus verifyTargetInternal(const Uptane::Target &target) const;
 
   std::unique_ptr<Bootloader> bootloader_;
+  std::string bootedStagedOstreeHash;
 };
 
 #endif  // OSTREE_H_


### PR DESCRIPTION
@mike-sul this approach seems to better simulate the `getCurrent` behavior in a staged environment. Both unit tests and rollback end-to-end tests work without problems. It even allowed a small workaround in the e2e tests, required with the previous approach, to be removed.
It relies on using a new external file, but that's how I was able to make it work when using the CLI.
I'll do a few more tests tomorrow.