### PR TITLE
[fio toup] ostree_object: Fix order of includes

### DIFF
--- a/src/sota_tools/ostree_object.h
+++ b/src/sota_tools/ostree_object.h
@@ -3,8 +3,8 @@
 
 #include <chrono>
 #include <iostream>
-#include <sstream>
 #include <list>
+#include <sstream>
 
 #include <curl/curl.h>
 #include <boost/filesystem/path.hpp>


### PR DESCRIPTION
The include added by 818b58fd3 ([fio toup] ostree_object: Add missing list include, 2025-03-21) was not in correct location, we missed the execution of the auto formatter.