### PR TITLE
Use boost::process::v1 namespace when building with Boost >= 1.88.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ if (CCACHE)
 endif (CCACHE)
 
 # find all required libraries
-set(BOOST_COMPONENTS log_setup log system filesystem program_options)
+set(BOOST_COMPONENTS log_setup log system filesystem program_options OPTIONAL_COMPONENTS process)
 set(Boost_USE_STATIC_LIBS OFF)
 add_definitions(-DBOOST_LOG_DYN_LINK)
 

--- a/src/aktualizr_get/get_test.cc
+++ b/src/aktualizr_get/get_test.cc
@@ -1,7 +1,5 @@
 #include <gtest/gtest.h>
 
-#include <boost/process.hpp>
-
 #include "get.h"
 #include "test_utils.h"
 
@@ -23,7 +21,7 @@ int main(int argc, char **argv) {
 
   std::string port = TestUtils::getFreePort();
   server += port;
-  boost::process::child server_process("tests/fake_http_server/fake_test_server.py", port);
+  bp::child server_process("tests/fake_http_server/fake_test_server.py", port);
   TestUtils::waitForServer(server + "/");
   return RUN_ALL_TESTS();
 }

--- a/src/aktualizr_secondary/aktualizr_secondary_ostree_test.cc
+++ b/src/aktualizr_secondary/aktualizr_secondary_ostree_test.cc
@@ -3,7 +3,6 @@
 #include <ostree.h>
 
 #include "boost/algorithm/string/trim.hpp"
-#include "boost/process.hpp"
 
 #include "logging/logging.h"
 #include "test_utils.h"
@@ -45,7 +44,7 @@ class Treehub {
   TemporaryDirectory root_dir_;
   const std::string port_;
   const std::string url_;
-  boost::process::child process_;
+  bp::child process_;
   std::string cur_rev_;
 };
 

--- a/src/libaktualizr-c/test/api-test-utils/api-test-utils.cc
+++ b/src/libaktualizr-c/test/api-test-utils/api-test-utils.cc
@@ -5,16 +5,16 @@
 #include "test_utils.h"
 #include "utilities/utils.h"
 
-std::string serverAddress;                      // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-std::unique_ptr<boost::process::child> server;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-std::unique_ptr<TemporaryDirectory> temp_dir;   // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+std::string serverAddress;                     // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+std::unique_ptr<bp::child> server;             // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+std::unique_ptr<TemporaryDirectory> temp_dir;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
 void Run_fake_http_server(const char *serverPath, const char *metaPath) {
   std::string port = TestUtils::getFreePort();
   serverAddress = "http://127.0.0.1:" + port;
 
   // NOLINTNEXTLINE(clang-analyzer-core.NonNullParamChecker)
-  server = std_::make_unique<boost::process::child>(serverPath, port, "-f", "-m", metaPath);
+  server = std_::make_unique<bp::child>(serverPath, port, "-f", "-m", metaPath);
   TestUtils::waitForServer(serverAddress + "/");
 }
 

--- a/src/libaktualizr-c/test/api-test-utils/api-test-utils.h
+++ b/src/libaktualizr-c/test/api-test-utils/api-test-utils.h
@@ -6,7 +6,7 @@
 #include "libaktualizr/config.h"
 
 using Config = Config;
-using FakeHttpServer = boost::process::child;
+using FakeHttpServer = bp::child;
 
 extern "C" {
 #else

--- a/src/libaktualizr/http/httpclient_test.cc
+++ b/src/libaktualizr/http/httpclient_test.cc
@@ -123,7 +123,7 @@ int main(int argc, char** argv) {
 
   std::string port = TestUtils::getFreePort();
   server += port;
-  boost::process::child server_process("tests/fake_http_server/fake_test_server.py", port, "-f");
+  bp::child server_process("tests/fake_http_server/fake_test_server.py", port, "-f");
   TestUtils::waitForServer(server + "/");
 
   return RUN_ALL_TESTS();

--- a/src/libaktualizr/package_manager/fetcher_death_test.cc
+++ b/src/libaktualizr/package_manager/fetcher_death_test.cc
@@ -129,7 +129,7 @@ int main(int argc, char** argv) {
   std::string port = TestUtils::getFreePort();
   server = "http://127.0.0.1:" + port;
   config.uptane.repo_server = server;
-  boost::process::child http_server_process("tests/fake_http_server/fake_test_server.py", port, "-f");
+  bp::child http_server_process("tests/fake_http_server/fake_test_server.py", port, "-f");
   TestUtils::waitForServer(server + "/");
   return RUN_ALL_TESTS();
 }

--- a/src/libaktualizr/package_manager/fetcher_test.cc
+++ b/src/libaktualizr/package_manager/fetcher_test.cc
@@ -365,15 +365,15 @@ int main(int argc, char** argv) {
 
   std::string port = TestUtils::getFreePort();
   server += port;
-  boost::process::child http_server_process("tests/fake_http_server/fake_test_server.py", port, "-f");
+  bp::child http_server_process("tests/fake_http_server/fake_test_server.py", port, "-f");
   TestUtils::waitForServer(server + "/");
 #ifdef BUILD_OSTREE
   std::string treehub_port = TestUtils::getFreePort();
   treehub_server += treehub_port;
   TemporaryDirectory treehub_dir;
-  boost::process::child ostree_server_process("tests/sota_tools/treehub_server.py", std::string("-p"), treehub_port,
-                                              std::string("-d"), treehub_dir.PathString(), std::string("-s0.5"),
-                                              std::string("--create"));
+  bp::child ostree_server_process("tests/sota_tools/treehub_server.py", std::string("-p"), treehub_port,
+                                  std::string("-d"), treehub_dir.PathString(), std::string("-s0.5"),
+                                  std::string("--create"));
   TemporaryDirectory temp_dir;
   int r = system((std::string("ostree admin init-fs ") + temp_dir.PathString()).c_str());
   if (r != 0) {

--- a/src/libaktualizr/primary/aktualizr_fullostree_test.cc
+++ b/src/libaktualizr/primary/aktualizr_fullostree_test.cc
@@ -139,15 +139,15 @@ int main(int argc, char **argv) {
 
   std::string port = TestUtils::getFreePort();
   server += port;
-  boost::process::child http_server_process("tests/fake_http_server/fake_test_server.py", port, "-m", meta_dir.Path());
+  bp::child http_server_process("tests/fake_http_server/fake_test_server.py", port, "-m", meta_dir.Path());
   TestUtils::waitForServer(server + "/");
 
   std::string treehub_port = TestUtils::getFreePort();
   treehub_server += treehub_port;
   TemporaryDirectory treehub_dir;
-  boost::process::child ostree_server_process("tests/sota_tools/treehub_server.py", std::string("-p"), treehub_port,
-                                              std::string("-d"), treehub_dir.PathString(), std::string("-s0.5"),
-                                              std::string("--create"));
+  bp::child ostree_server_process("tests/sota_tools/treehub_server.py", std::string("-p"), treehub_port,
+                                  std::string("-d"), treehub_dir.PathString(), std::string("-s0.5"),
+                                  std::string("--create"));
   TestUtils::waitForServer(treehub_server + "/");
   r = ostree.run({"rev-parse", std::string("--repo"), treehub_dir.PathString(), "master"});
   if (std::get<0>(r) != 0) {

--- a/src/libaktualizr/primary/aktualizr_lite_test.cc
+++ b/src/libaktualizr/primary/aktualizr_lite_test.cc
@@ -49,7 +49,7 @@ class TufRepoMock {
   ImageRepo repo_;
   std::string port_;
   std::string url_;
-  boost::process::child process_;
+  bp::child process_;
 };
 
 class Treehub {
@@ -92,7 +92,7 @@ class Treehub {
   const std::string root_dir_;
   std::string port_;
   std::string url_;
-  boost::process::child process_;
+  bp::child process_;
 };
 
 class ComposeAppPackManMock : public OstreeManager {

--- a/src/libaktualizr/primary/download_nonostree_test.cc
+++ b/src/libaktualizr/primary/download_nonostree_test.cc
@@ -68,14 +68,14 @@ int main(int argc, char **argv) {
 
   std::string port = TestUtils::getFreePort();
   server += port;
-  boost::process::child http_server_process("tests/fake_http_server/fake_test_server.py", port, "-m", meta_dir.Path());
+  bp::child http_server_process("tests/fake_http_server/fake_test_server.py", port, "-m", meta_dir.Path());
   TestUtils::waitForServer(server + "/");
   std::string treehub_port = TestUtils::getFreePort();
   treehub_server += treehub_port;
   TemporaryDirectory treehub_dir;
-  boost::process::child ostree_server_process("tests/sota_tools/treehub_server.py", std::string("-p"), treehub_port,
-                                              std::string("-d"), treehub_dir.PathString(), std::string("-s0.5"),
-                                              std::string("--create"));
+  bp::child ostree_server_process("tests/sota_tools/treehub_server.py", std::string("-p"), treehub_port,
+                                  std::string("-d"), treehub_dir.PathString(), std::string("-s0.5"),
+                                  std::string("--create"));
   TestUtils::waitForServer(treehub_server + "/");
 
   Process uptane_gen(uptane_generator_path.string());

--- a/src/libaktualizr/uptane/uptane_network_test.cc
+++ b/src/libaktualizr/uptane/uptane_network_test.cc
@@ -205,7 +205,7 @@ int main(int argc, char **argv) {
   logger_set_threshold(boost::log::trivial::trace);
 
   port = TestUtils::getFreePort();
-  boost::process::child server_process("tests/fake_http_server/fake_uptane_server.py", port);
+  bp::child server_process("tests/fake_http_server/fake_uptane_server.py", port);
   TestUtils::waitForServer("http://127.0.0.1:" + port + "/");
 
   conf.provision.server = "http://127.0.0.1:" + port;

--- a/src/sota_tools/authenticate_test.cc
+++ b/src/sota_tools/authenticate_test.cc
@@ -123,9 +123,8 @@ int main(int argc, char **argv) {
   }
   certs_dir = argv[1];
 
-  boost::process::child server_process("tests/sota_tools/authentication/tls_server.py", "1443", certs_dir);
-  boost::process::child server_noauth_process("tests/sota_tools/authentication/tls_server.py", "--noauth", "2443",
-                                              certs_dir);
+  bp::child server_process("tests/sota_tools/authentication/tls_server.py", "1443", certs_dir);
+  bp::child server_noauth_process("tests/sota_tools/authentication/tls_server.py", "--noauth", "2443", certs_dir);
   // TODO: this do not work because the server expects auth! Let's sleep for now.
   // (could be replaced by a check with raw tcp)
   // TestUtils::waitForServer("https://localhost:1443/");

--- a/src/sota_tools/deploy_test.cc
+++ b/src/sota_tools/deploy_test.cc
@@ -52,8 +52,8 @@ int main(int argc, char **argv) {
   auth["ostree"]["server"] = std::string("https://localhost:") + port;
   Utils::writeFile(temp_dir.Path() / "auth.json", auth);
 
-  boost::process::child server_process(server, std::string("-p"), port, std::string("-d"), temp_dir.PathString(),
-                                       std::string("--tls"));
+  bp::child server_process(server, std::string("-p"), port, std::string("-d"), temp_dir.PathString(),
+                           std::string("--tls"));
   TestUtils::waitForServer("https://localhost:" + port + "/");
   return RUN_ALL_TESTS();
 }

--- a/src/sota_tools/ostree_http_repo_test.cc
+++ b/src/sota_tools/ostree_http_repo_test.cc
@@ -72,8 +72,8 @@ TEST(http_repo, bad_connection) {
   TemporaryDirectory src_dir, dst_dir;
   std::string sp = TestUtils::getFreePort();
 
-  boost::process::child server_process("tests/sota_tools/treehub_server.py", std::string("-p"), sp, std::string("-d"),
-                                       src_dir.PathString(), std::string("-f2"), std::string("--create"));
+  bp::child server_process("tests/sota_tools/treehub_server.py", std::string("-p"), sp, std::string("-d"),
+                           src_dir.PathString(), std::string("-f2"), std::string("--create"));
   TestUtils::waitForServer("http://localhost:" + sp + "/");
 
   TreehubServer server;
@@ -84,9 +84,8 @@ TEST(http_repo, bad_connection) {
   Json::Value auth;
   auth["ostree"]["server"] = std::string("https://localhost:") + dp;
   Utils::writeFile(dst_dir.Path() / "auth.json", auth);
-  boost::process::child deploy_server_process("tests/sota_tools/treehub_server.py", std::string("-p"), dp,
-                                              std::string("-d"), dst_dir.PathString(), std::string("-f2"),
-                                              std::string("--tls"));
+  bp::child deploy_server_process("tests/sota_tools/treehub_server.py", std::string("-p"), dp, std::string("-d"),
+                                  dst_dir.PathString(), std::string("-f2"), std::string("--tls"));
   TestUtils::waitForServer("https://localhost:" + dp + "/");
 
   boost::filesystem::path filepath = (dst_dir.Path() / "auth.json").string();
@@ -124,7 +123,7 @@ int main(int argc, char **argv) {
   std::string server = "tests/sota_tools/treehub_server.py";
   port = TestUtils::getFreePort();
 
-  boost::process::child server_process(server, std::string("-p"), port, std::string("--create"));
+  bp::child server_process(server, std::string("-p"), port, std::string("--create"));
   TestUtils::waitForServer("http://localhost:" + port + "/");
 
   return RUN_ALL_TESTS();

--- a/src/sota_tools/ostree_object_test.cc
+++ b/src/sota_tools/ostree_object_test.cc
@@ -172,8 +172,8 @@ TEST(OstreeObject, UploadSuccess) {
   Json::Value auth;
   auth["ostree"]["server"] = std::string("https://localhost:") + dp;
   Utils::writeFile(temp_dir.Path() / "auth.json", auth);
-  boost::process::child deploy_server_process("tests/sota_tools/treehub_server.py", std::string("-p"), dp,
-                                              std::string("-d"), temp_dir.Path().string(), std::string("--tls"));
+  bp::child deploy_server_process("tests/sota_tools/treehub_server.py", std::string("-p"), dp, std::string("-d"),
+                                  temp_dir.Path().string(), std::string("--tls"));
   TestUtils::waitForServer("https://localhost:" + dp + "/");
 
   TreehubServer push_server;
@@ -230,8 +230,7 @@ int main(int argc, char** argv) {
   TemporaryDirectory repo_dir;
   repo_path = repo_dir.PathString();
 
-  boost::process::child server_process(server, std::string("-p"), port, std::string("-d"), repo_path,
-                                       std::string("--create"));
+  bp::child server_process(server, std::string("-p"), port, std::string("-d"), repo_path, std::string("--create"));
   TestUtils::waitForServer("http://localhost:" + port + "/");
 
   return RUN_ALL_TESTS();

--- a/src/sota_tools/treehub_server_test.cc
+++ b/src/sota_tools/treehub_server_test.cc
@@ -67,7 +67,7 @@ int main(int argc, char **argv) {
   std::string server = "tests/sota_tools/headers_response_server.py";
   port = TestUtils::getFreePort();
 
-  boost::process::child server_process(server, port);
+  bp::child server_process(server, port);
   TestUtils::waitForServer("http://127.0.0.1:" + port + "/");
 
   return RUN_ALL_TESTS();

--- a/tests/test_utils.cc
+++ b/tests/test_utils.cc
@@ -9,13 +9,13 @@
 #endif
 #include <chrono>
 #include <fstream>
+#include <future>
 #include <iostream>
 #include <string>
 #include <thread>
 
 #include <boost/asio/io_context.hpp>
 #include <boost/filesystem.hpp>
-#include <boost/process.hpp>
 
 #include "logging/logging.h"
 
@@ -95,11 +95,10 @@ Process::Result Process::spawn(const std::string &executable_to_run, const std::
     if (boost::filesystem::exists(executable_to_run)) {
       executable_path = executable_to_run;
     } else {
-      executable_path = boost::process::search_path(executable_to_run).string();
+      executable_path = bp::search_path(executable_to_run).string();
     }
-    boost::process::child child_process(boost::process::exe = executable_path, boost::process::args = executable_args,
-                                        boost::process::std_out > output, boost::process::std_err > err_output,
-                                        boost::process::on_exit = child_process_exit_code, io_context);
+    bp::child child_process(bp::exe = executable_path, bp::args = executable_args, bp::std_out > output,
+                            bp::std_err > err_output, bp::on_exit = child_process_exit_code, io_context);
 
     io_context.run();
 

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -8,6 +8,32 @@
 
 #include "utilities/utils.h"
 
+#include <boost/version.hpp>
+#if BOOST_VERSION >= 108800
+#include <boost/process/v1/args.hpp>
+#include <boost/process/v1/async.hpp>
+#include <boost/process/v1/async_system.hpp>
+#include <boost/process/v1/child.hpp>
+#include <boost/process/v1/cmd.hpp>
+#include <boost/process/v1/env.hpp>
+#include <boost/process/v1/environment.hpp>
+#include <boost/process/v1/error.hpp>
+#include <boost/process/v1/exe.hpp>
+#include <boost/process/v1/group.hpp>
+#include <boost/process/v1/handles.hpp>
+#include <boost/process/v1/io.hpp>
+#include <boost/process/v1/pipe.hpp>
+#include <boost/process/v1/search_path.hpp>
+#include <boost/process/v1/shell.hpp>
+#include <boost/process/v1/spawn.hpp>
+#include <boost/process/v1/start_dir.hpp>
+#include <boost/process/v1/system.hpp>
+namespace bp = boost::process::v1;
+#else
+#include <boost/process.hpp>
+namespace bp = boost::process;
+#endif
+
 struct TestUtils {
   static std::string getFreePort();
   static in_port_t getFreePortAsInt();


### PR DESCRIPTION
This allows building with Boost 1.88.0. Warnings are generated for deprecated methods.