### PR TITLE
Fix osname passing

### DIFF
--- a/src/libaktualizr/package_manager/ostreemanager.cc
+++ b/src/libaktualizr/package_manager/ostreemanager.cc
@@ -461,7 +461,7 @@ bool OstreeManager::imageUpdated() {
   GPtrArray *deployments = ostree_sysroot_get_deployments(sysroot_smart.get());
 
   OstreeDeployment *pending_deployment = nullptr;
-  ostree_sysroot_query_deployments_for(sysroot_smart.get(), nullptr, &pending_deployment, nullptr);
+  ostree_sysroot_query_deployments_for(sysroot_smart.get(), config.os.c_str(), &pending_deployment, nullptr);
 
   bool pending_found = false;
   for (guint i = 0; i < deployments->len; i++) {


### PR DESCRIPTION
It turned out that the `osname` set in the aktualizr config was not passed to the ostree API call to query deployments. It was not a problem until newer versions of ostree (e.g. 2024.5) started requiring the `osname` parameter to be set in any "ostree sysroot" related calls in a non-booted environment. This is the fix for this issue.
