### PR TITLE
[fio toup] config: Do not exit on broken config symlinks

### DIFF
--- a/src/libaktualizr/config/base_config.cc
+++ b/src/libaktualizr/config/base_config.cc
@@ -39,7 +39,11 @@ void BaseConfig::updateFromDirs(const std::vector<boost::filesystem::path>& conf
     }
   }
   for (const auto& config_file : configs_map) {
-    updateFromToml(config_file.second);
+    if (!boost::filesystem::exists(config_file.second)) {
+      LOG_ERROR << "Config file " << config_file.second << " does not exist.";
+    } else {
+      updateFromToml(config_file.second);
+    }
   }
 }
 


### PR DESCRIPTION
If some .toml file is listed in a config directory, but is detected as non existing, log an error message, but do not stop execution.

Keep the original behavior when trying to read a specific file instead of a directory, that's why the change was made outside `updateFromToml`.