### PR TITLE
CMakeLists.txt: Boost.System is now header-only

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ if (CCACHE)
 endif (CCACHE)
 
 # find all required libraries
-set(BOOST_COMPONENTS log_setup log system filesystem program_options OPTIONAL_COMPONENTS process)
+set(BOOST_COMPONENTS log_setup log filesystem program_options OPTIONAL_COMPONENTS process)
 set(Boost_USE_STATIC_LIBS OFF)
 add_definitions(-DBOOST_LOG_DYN_LINK)
 


### PR DESCRIPTION
In Boost 1.89.0 release, Boost.System stub library has been removed.

Ref: https://github.com/boostorg/system/commit/7a495bb46d7ccd808e4be2a6589260839b0fd3a3